### PR TITLE
Fix presence penalty key name

### DIFF
--- a/source/openai/chat.d
+++ b/source/openai/chat.d
@@ -498,7 +498,7 @@ struct ChatCompletionRequest
 
     ///
     @serdeIgnoreDefault
-    @serdeIgnoreOutIf!isNaN @serdeKeys("presence_panealty")
+    @serdeIgnoreOutIf!isNaN @serdeKeys("presence_penalty")
     double presencePenalty = 0;
 
     ///


### PR DESCRIPTION
## Summary
- fix presence_penalty key name in `ChatCompletionRequest`

## Testing
- `dub test -q`

------
https://chatgpt.com/codex/tasks/task_e_68418348a1cc832c9c6d1c511d1ad787