### PR TITLE
Fix typo in README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
 - [x] Models
 - [x] Moderations
 - [ ] Assistants (Beta)
-- [ ] Addministration
+- [ ] Administration
 - [ ] Realtime
 
 __legacy__


### PR DESCRIPTION
## Summary
- correct spelling for Administration in README

## Testing
- `apt-get update`
- `apt-get install -y dub`
- `dub build`

------
https://chatgpt.com/codex/tasks/task_e_6841847c53c4832c8b049f07ab62ecf2