### PR TITLE
Add reasoning effort constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ taskchain-test-*
 *.o
 *.obj
 *.lst
+dub.selections.json
+openai-d-test-library

--- a/source/openai/chat.d
+++ b/source/openai/chat.d
@@ -420,6 +420,13 @@ struct ChatCompletionAudioParam
     string voice;
 }
 
+/// Valid values for `ChatCompletionRequest.reasoningEffort`
+enum ReasoningEffortLow = "low";
+/// ditto
+enum ReasoningEffortMedium = "medium";
+/// ditto
+enum ReasoningEffortHigh = "high";
+
 ///
 struct ChatCompletionRequest
 {
@@ -437,6 +444,7 @@ struct ChatCompletionRequest
     ///
     @serdeIgnoreDefault
     @serdeKeys("reasoning_effort")
+    /// Use `ReasoningEffortLow`, `ReasoningEffortMedium` or `ReasoningEffortHigh`.
     string reasoningEffort;
 
     ///


### PR DESCRIPTION
## Summary
- provide `ReasoningEffortLow`, `ReasoningEffortMedium` and `ReasoningEffortHigh`
- document valid `reasoningEffort` values in `ChatCompletionRequest`
- ignore dub build artifacts

## Testing
- `dub test -q`

------
https://chatgpt.com/codex/tasks/task_e_68418fbe6228832ca8289c8089b067f7