### PR TITLE
[models] add ModelsResponse unit test

### DIFF
--- a/source/openai/common.d
+++ b/source/openai/common.d
@@ -880,7 +880,7 @@ unittest
         bool isCool;
     }
 
-    const requiredFields = ["name", "age"];
+    string[] requiredFields = ["name", "age"];
 
     auto schema = JsonSchema.object_([
         "name": JsonSchema.string_(),

--- a/source/openai/models.d
+++ b/source/openai/models.d
@@ -193,3 +193,17 @@ struct ModelsResponse
     ///
     string object;
 }
+
+unittest
+{
+    import mir.deser.json;
+
+    const json = `{"object":"list","data":[{"id":"gpt-3.5-turbo","created":0,"object":"model","owned_by":"openai"}]}`;
+    auto response = deserializeJson!ModelsResponse(json);
+
+    assert(response.object == "list");
+    assert(response.data.length == 1);
+    assert(response.data[0].id == "gpt-3.5-turbo");
+    assert(response.data[0].ownedBy == "openai");
+    assert(response.data[0].object == "model");
+}


### PR DESCRIPTION
## Summary
- add a unit test for `ModelsResponse`
- adjust a test helper in `common.d` to compile on DMD

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_68446978fe44832c9887e679b1603dd6