### PR TITLE
[examples] remove config.json from vision sample

### DIFF
--- a/examples/chat_vision/.gitattributes
+++ b/examples/chat_vision/.gitattributes
@@ -1,0 +1,3 @@
+*.d text
+*.sdl text
+*.json text

--- a/examples/chat_vision/dub.sdl
+++ b/examples/chat_vision/dub.sdl
@@ -1,0 +1,6 @@
+name "chat_vision"
+description "A minimal D application."
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/chat_vision/dub.selections.json
+++ b/examples/chat_vision/dub.selections.json
@@ -5,7 +5,6 @@
                 "mir-core": "1.7.1",
                 "mir-cpuid": "1.2.11",
                 "mir-ion": "2.3.3",
-                "openai-d": {"path":"../.."},
-                "silly": "1.1.1"
+                "openai-d": {"path":"../.."}
         }
 }

--- a/examples/chat_vision/dub.selections.json
+++ b/examples/chat_vision/dub.selections.json
@@ -1,0 +1,11 @@
+{
+        "fileVersion": 1,
+        "versions": {
+                "mir-algorithm": "3.22.3",
+                "mir-core": "1.7.1",
+                "mir-cpuid": "1.2.11",
+                "mir-ion": "2.3.3",
+                "openai-d": {"path":"../.."},
+                "silly": "1.1.1"
+        }
+}

--- a/examples/chat_vision/source/app.d
+++ b/examples/chat_vision/source/app.d
@@ -8,8 +8,6 @@ import openai;
 void main()
 {
     // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     // Load local image and convert to data URL

--- a/examples/chat_vision/source/app.d
+++ b/examples/chat_vision/source/app.d
@@ -1,0 +1,29 @@
+import std.stdio;
+import std.file : read;
+import std.base64;
+import std.conv : to;
+
+import openai;
+
+void main()
+{
+    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
+    // auto config = OpenAIClientConfig.fromFile("config.json");
+    // auto client = new OpenAIClient(config);
+    auto client = new OpenAIClient;
+
+    // Load local image and convert to data URL
+    auto bytes = cast(ubyte[]) read("assets/cat.png");
+    string dataUri = to!string("data:image/png;base64," ~ Base64.encode(bytes));
+
+    auto request = chatCompletionRequest(openai.GPT4OMini /* gpt-4o */ , [
+        userChatMessageWithImages("この画像の内容を詳しく説明してください。", [
+            dataUri
+        ])
+    ], 1024, 0);
+
+    auto response = client.chatCompletion(request);
+    assert(response.choices.length > 0);
+
+    writeln(response.choices[0].message.content);
+}


### PR DESCRIPTION
## Summary
- remove unused `config.json`
- cast data URI to string for `chat_vision` build

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `dub build` in `examples/chat_vision`
- `dub run dfmt -- examples` *(failed: dfmt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b3bca788832cabe3bdb71eaf35ac