### PR TITLE
[ci] build examples in CI

### DIFF
--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -24,6 +24,11 @@ jobs:
         run: dub lint --dscanner-config dscanner.ini
       - name: Test
         run: dub test --compiler=$DC
+      - name: Build examples
+        run: |
+          for dir in examples/*; do
+            (cd "$dir" && dub build --compiler=$DC)
+          done
 
   build-windows:
     runs-on: windows-latest
@@ -44,3 +49,11 @@ jobs:
         run: dub lint --dscanner-config dscanner.ini
       - name: Test
         run: dub test --compiler=$Env:DC
+      - name: Build examples
+        shell: pwsh
+        run: |
+          Get-ChildItem examples -Directory | ForEach-Object {
+            Push-Location $_.FullName
+            dub build --compiler=$Env:DC
+            Pop-Location
+          }


### PR DESCRIPTION
## Summary
- ensure each directory in `examples/` builds during CI
- run example builds on both Ubuntu and Windows GitHub Actions jobs

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `for d in examples/*; do (cd "$d" && dub build); done`

------
https://chatgpt.com/codex/tasks/task_e_684541003714832cac234af76e65f950