### PR TITLE
[examples] cleanup transcription workflow

### DIFF
--- a/examples/audio_transcription/dub.sdl
+++ b/examples/audio_transcription/dub.sdl
@@ -1,0 +1,6 @@
+name "audio_transcription"
+description "A minimal D application."
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/audio_transcription/dub.selections.json
+++ b/examples/audio_transcription/dub.selections.json
@@ -1,0 +1,11 @@
+{
+        "fileVersion": 1,
+        "versions": {
+                "mir-algorithm": "3.22.3",
+                "mir-core": "1.7.1",
+                "mir-cpuid": "1.2.11",
+                "mir-ion": "2.3.3",
+                "openai-d": {"path":"../.."},
+                "silly": "1.1.1"
+        }
+}

--- a/examples/audio_transcription/source/app.d
+++ b/examples/audio_transcription/source/app.d
@@ -1,0 +1,13 @@
+import std.stdio;
+
+import openai;
+
+void main(string[] args)
+{
+    string file = args.length > 1 ? args[1] : "audio.mp3";
+    auto client = new OpenAIClient;
+
+    auto request = transcriptionRequest(file, "whisper-1");
+    auto response = client.transcription(request);
+    writeln(response.text);
+}


### PR DESCRIPTION
## Summary
- remove extra CI steps for audio_transcription example
- delete placeholder `config.json`

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `for dir in examples/*; do (cd "$dir" && dub build); done` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6846e4ee1be4832cb8cbcd23aeff43e9