### PR TITLE
[docs] add transcription example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
 - [ ] [Realtime (Beta)](https://platform.openai.com/docs/api-reference/realtime) (TODO)
 - [x] [Audio](https://platform.openai.com/docs/api-reference/audio)
   - [x] speech
-  - [ ] transcription (TODO)
+  - [x] transcription
   - [ ] translations (TODO)
 - [ ] [Images](https://platform.openai.com/docs/api-reference/images) (TODO)
 - [x] [Embeddings](https://platform.openai.com/docs/api-reference/embeddings)
@@ -147,6 +147,24 @@ if (response.results[0].flagged)
 else
     writeln("Probably safe.");
 ```
+
+__Transcription__
+
+```d name=transcription
+import std;
+import openai;
+
+// Load API key from environment variable
+auto client = new OpenAIClient();
+
+// POST /audio/transcriptions
+auto request = transcriptionRequest("audio.mp3", "whisper-1");
+auto response = client.transcription(request);
+
+writeln(response.text);
+```
+
+See `examples/audio_transcription` for a complete example.
 
 ## OpenAIClientConfig
 


### PR DESCRIPTION
## Summary
- mark audio transcription as implemented in Features table
- demonstrate how to transcribe audio using `OpenAIClient.transcription`
- point to `examples/audio_transcription` in README

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `for d in examples/*; do echo "building $d"; pushd $d >/dev/null; dub build >/tmp/example_build.txt && tail -n 2 /tmp/example_build.txt; popd >/dev/null; done`

------
https://chatgpt.com/codex/tasks/task_e_6846efdefca0832c917458b10dbcc69d