### PR TITLE
[openai] add speech URL tests

### DIFF
--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -598,6 +598,29 @@ class OpenAIClient
         assert(client.buildUrl("/audio/translations") ==
                 "https://westus.api.cognitive.microsoft.com/openai/deployments/dep/audio/translations?api-version=2024-05-01");
     }
+
+    @("buildUrl speech - openai")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/audio/speech") ==
+                "https://api.openai.com/v1/audio/speech");
+    }
+
+    @("buildUrl speech - azure")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        cfg.apiBase = "https://westus.api.cognitive.microsoft.com";
+        cfg.deploymentId = "dep";
+        cfg.apiVersion = "2024-05-01";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/audio/speech") ==
+                "https://westus.api.cognitive.microsoft.com/openai/deployments/dep/audio/speech?api-version=2024-05-01");
+    }
 }
 
 @("config from environment - openai mode")


### PR DESCRIPTION
## Summary
- test URL building for `/audio/speech`

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `dub --root=examples/chat_db build`
- `dub --root=examples/chat_tools build -q`
- `dub --root=examples/chat_vision build -q`
- `dub --root=examples/completion build -q`
- `dub --root=examples/embedding build -q`
- `dub --root=examples/models build -q`
- `dub --root=examples/moderation build -q`
- `dub --root=examples/reasoning build -q`
- `dub --root=examples/structured_output build -q`
- `dub --root=examples/audio_speech build -q`
- `dub --root=examples/audio_transcription build -q`


------
https://chatgpt.com/codex/tasks/task_e_6846fc40924c832cb53ca3f5f3d6037a