### PR TITLE
[examples] add audio translation sample

### DIFF
--- a/examples/audio_translation/dub.sdl
+++ b/examples/audio_translation/dub.sdl
@@ -1,0 +1,6 @@
+name "audio_translation"
+description "A minimal D application."
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/audio_translation/dub.selections.json
+++ b/examples/audio_translation/dub.selections.json
@@ -1,0 +1,11 @@
+{
+        "fileVersion": 1,
+        "versions": {
+                "mir-algorithm": "3.22.3",
+                "mir-core": "1.7.1",
+                "mir-cpuid": "1.2.11",
+                "mir-ion": "2.3.3",
+                "openai-d": {"path":"../.."},
+                "silly": "1.1.1"
+        }
+}

--- a/examples/audio_translation/source/app.d
+++ b/examples/audio_translation/source/app.d
@@ -1,0 +1,11 @@
+import std.stdio;
+import openai;
+
+void main(string[] args)
+{
+    string file = args.length > 1 ? args[1] : "audio.mp3";
+    auto client = new OpenAIClient;
+    auto request = translationRequest(file, "whisper-1");
+    auto res = client.translation(request);
+    writeln(res.text);
+}


### PR DESCRIPTION
## Summary
- add an audio translation example folder
- demonstrate calling `OpenAIClient.translation`

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `for dir in examples/*/; do dub build; done`

------
https://chatgpt.com/codex/tasks/task_e_6846fc41a204832c9af17d4a1aa4cc38