### PR TITLE
[client] specify return type for audio methods

### DIFF
--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -339,7 +339,7 @@ class OpenAIClient
     }
 
     ///
-    auto transcription(in TranscriptionRequest request) @system
+    AudioTextResponse transcription(in TranscriptionRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (request.file.length > 0)
     in (request.model.length > 0)
@@ -414,7 +414,7 @@ class OpenAIClient
     }
 
     ///
-    auto translation(in TranslationRequest request) @system
+    AudioTextResponse translation(in TranslationRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (request.file.length > 0)
     in (request.model.length > 0)


### PR DESCRIPTION
## Summary
- specify return type `AudioTextResponse` for `transcription` and `translation`

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `dub build` in each example directory

------
https://chatgpt.com/codex/tasks/task_e_6848072af65c832cbabaf88ddbd78136