### PR TITLE
fix(chat): remove logitBias due to JsonAlgebraic limitations

### DIFF
--- a/source/openai/chat.d
+++ b/source/openai/chat.d
@@ -534,10 +534,10 @@ struct ChatCompletionRequest
     @serdeIgnoreDefault
     Nullable!int seed = null;
 
-    ///
-    @serdeIgnoreDefault
-    @serdeKeys("logit_bias")
-    StringMap!double logitBias;
+    // Reason: mir-algorithm's JsonAlgebraic does not support associative arrays with int or uint keys.
+    // @serdeIgnoreDefault
+    // @serdeKeys("logit_bias")
+    // float[int] logitBias;
 
     ///
     @serdeIgnoreDefault
@@ -646,21 +646,6 @@ unittest
     string expectedJson = `{"model":"gpt-4o-mini","messages":[{"role":"system","content":"Welcome!"},{"role":"user","content":"How can I use the tools?","name":"User123"}],"max_completion_tokens":20,"tools":[{"type":"function","function":{"name":"sample_function","description":"Sample tool function","parameters":{"type":"string","description":"tool argument"}}}],"tool_choice":"auto"}`;
 
     assert(jsonString == expectedJson, jsonString ~ "\n" ~ expectedJson);
-}
-
-unittest
-{
-    ChatCompletionRequest request;
-    request.model = "gpt-4o-mini";
-    request.messages = [userChatMessage("Hi")];
-    request.logitBias["123"] = 1.0;
-
-    import mir.ser.json;
-
-    assert(
-        serializeJson(
-            request) ==
-            `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hi"}],"logit_bias":{"123":1.0}}`);
 }
 
 unittest

--- a/source/openai/completion.d
+++ b/source/openai/completion.d
@@ -72,10 +72,11 @@ struct CompletionRequest
     ///
     @serdeIgnoreDefault
     uint bestOf = 1;
-    ///
-    @serdeIgnoreDefault
-    @serdeKeys("logit_bias")
-    StringMap!double logitBias;
+
+    // Reason: mir-algorithm's JsonAlgebraic does not support associative arrays with int or uint keys.
+    // @serdeIgnoreDefault
+    // @serdeKeys("logit_bias")
+    // float[int] logitBias;
 
     ///
     @serdeIgnoreDefault
@@ -91,20 +92,6 @@ CompletionRequest completionRequest(string model, string prompt, uint maxTokens,
     request.maxTokens = maxTokens;
     request.temperature = temperature;
     return request;
-}
-
-unittest
-{
-    CompletionRequest request;
-    request.model = "gpt-3.5-turbo-instruct";
-    request.prompt = "hello";
-    request.logitBias["42"] = -1.0;
-
-    import mir.ser.json;
-
-    assert(
-        serializeJson(request) ==
-            `{"model":"gpt-3.5-turbo-instruct","prompt":"hello","logitBias":{"42":-1.0}}`);
 }
 
 ///


### PR DESCRIPTION
This pull request removes support for the `logitBias` field in both `ChatCompletionRequest` and `CompletionRequest` structures due to compatibility issues with `mir-algorithm`'s `JsonAlgebraic`. Additionally, related unit tests for `logitBias` serialization have been removed.

### Removal of `logitBias` field:
* [`source/openai/chat.d`](diffhunk://#diff-b10c6a982d63dba3f9de4cf3586f454afbd5edcddf0b1d774f9931177d2be10bL537-R540): Removed the `logitBias` field from `ChatCompletionRequest` and added comments explaining the removal due to incompatibility with `mir-algorithm`'s `JsonAlgebraic`.
* [`source/openai/completion.d`](diffhunk://#diff-6b79bfc4ff00acc9088a85ea6ee3781277b0605cfb54f42b0b8bc9dff4b66afcL75-R79): Removed the `logitBias` field from `CompletionRequest` with similar explanatory comments.

### Removal of related unit tests:
* [`source/openai/chat.d`](diffhunk://#diff-b10c6a982d63dba3f9de4cf3586f454afbd5edcddf0b1d774f9931177d2be10bL651-L665): Deleted unit tests for `logitBias` serialization in `ChatCompletionRequest`.
* [`source/openai/completion.d`](diffhunk://#diff-6b79bfc4ff00acc9088a85ea6ee3781277b0605cfb54f42b0b8bc9dff4b66afcL96-L109): Deleted unit tests for `logitBias` serialization in `CompletionRequest`.