### PR TITLE
[examples] remove config files and add config constructor sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,12 @@ auto config = OpenAIClientConfig.fromFile("config.json");
 assert(config.apiKey == "<Your API Key>");
 assert(config.organization is null);
 ```
+
+__Constructor__
+
+```d name=config_direct
+import openai;
+
+auto config = new OpenAIClientConfig("<Your OpenAI API Key>");
+auto client = new OpenAIClient(config);
+```

--- a/examples/audio_speech/config.json
+++ b/examples/audio_speech/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/chat/config.json
+++ b/examples/chat/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/chat/source/app.d
+++ b/examples/chat/source/app.d
@@ -4,9 +4,6 @@ import openai;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     const request = chatCompletionRequest(openai.GPT4OMini, [

--- a/examples/chat_db/config.json
+++ b/examples/chat_db/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/chat_db/source/app.d
+++ b/examples/chat_db/source/app.d
@@ -9,9 +9,6 @@ import d2sqlite3;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     auto db = Database(":memory:");

--- a/examples/chat_tools/source/app.d
+++ b/examples/chat_tools/source/app.d
@@ -6,9 +6,6 @@ import openai;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     auto request = chatCompletionRequest("gpt-4o-mini", [

--- a/examples/chat_vision/source/app.d
+++ b/examples/chat_vision/source/app.d
@@ -7,7 +7,6 @@ import openai;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
     auto client = new OpenAIClient;
 
     // Load local image and convert to data URL

--- a/examples/completion/config.json
+++ b/examples/completion/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/completion/source/app.d
+++ b/examples/completion/source/app.d
@@ -5,9 +5,6 @@ import openai;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     // POST /completions

--- a/examples/embedding/config.json
+++ b/examples/embedding/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/embedding/source/app.d
+++ b/examples/embedding/source/app.d
@@ -4,9 +4,6 @@ import openai;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     auto request = embeddingRequest(openai.AdaEmbeddingV2, "Hello, world!");

--- a/examples/models/config.json
+++ b/examples/models/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/models/source/app.d
+++ b/examples/models/source/app.d
@@ -8,9 +8,6 @@ import openai;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     auto models = client.listModels();

--- a/examples/moderation/config.json
+++ b/examples/moderation/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/moderation/source/app.d
+++ b/examples/moderation/source/app.d
@@ -6,9 +6,6 @@ import openai;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     // POST /moderations

--- a/examples/reasoning/config.json
+++ b/examples/reasoning/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/structured_output/config.json
+++ b/examples/structured_output/config.json
@@ -1,1 +1,0 @@
-{"apiKey":"<Your OpenAI API Key>","organization":""}

--- a/examples/structured_output/source/app.d
+++ b/examples/structured_output/source/app.d
@@ -7,9 +7,6 @@ import mir.algebraic;
 
 void main()
 {
-    // If the argument Config is omitted, it is read from an environment variable 'OPENAI_API_KEY'
-    // auto config = OpenAIClientConfig.fromFile("config.json");
-    // auto client = new OpenAIClient(config);
     auto client = new OpenAIClient;
 
     auto request = chatCompletionRequest(openai.GPT4OMini, [

--- a/source/openai/completion.d
+++ b/source/openai/completion.d
@@ -104,7 +104,7 @@ unittest
 
     assert(
         serializeJson(request) ==
-            `{"model":"gpt-3.5-turbo-instruct","prompt":"hello","logitBias":{"42":-1.0}}`);
+            `{"model":"gpt-3.5-turbo-instruct","prompt":"hello","logit_bias":{"42":-1.0}}`);
 }
 
 ///


### PR DESCRIPTION
## Summary
- remove example `config.json` files
- clean up old Config comments
- show how to pass API key via `OpenAIClientConfig`
- fix failing completion test

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub build` in each example directory

------
https://chatgpt.com/codex/tasks/task_e_68483180153c832ca43fd77283b40225