### PR TITLE
[docs] document request helpers

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -15,3 +15,18 @@
 <!-- reflection-template:end -->
 
 ## :memo: Reflection History
+<!-- reflection-template:start -->
+### :book: Reflection for 2025-06-11
+- **Task**: Document request helper functions
+- **Objective**: Clarify usage of helper constructors for OpenAI API requests
+- **Outcome**: Added Ddoc comments summarizing parameters and target endpoints
+
+### :sparkles: What went well
+- Prebuilt examples compiled successfully after changes
+
+### :warning: Pain points
+- Compiling each example manually is repetitive
+
+### :bulb: Proposed Improvement
+- Provide a helper script to build all example projects in one step
+<!-- reflection-template:end -->

--- a/source/openai/audio.d
+++ b/source/openai/audio.d
@@ -98,7 +98,17 @@ struct SpeechRequest
     double speed = 1;
 }
 
-/// Convenience constructor for `SpeechRequest`.
+/**
+ * Convenience constructor for creating a `SpeechRequest` used with the
+ * `/audio/speech` endpoint.
+ *
+ * Params:
+ *     model = ID of the text-to-speech model.
+ *     input = Text to synthesize.
+ *     voice = Voice identifier. The request defaults to MP3 format at speed 1.0.
+ *
+ * Returns: Request object suitable for `OpenAIClient.speech`.
+ */
 SpeechRequest speechRequest(string model, string input, string voice)
 {
     auto request = SpeechRequest();
@@ -149,7 +159,19 @@ struct TranscriptionRequest
     bool stream = false;
 }
 
-/// Convenience constructor for `TranscriptionRequest`.
+/**
+ * Convenience constructor for `TranscriptionRequest` objects sent to the
+ * `/audio/transcriptions` endpoint.
+ *
+ * Params:
+ *     file  = Path to the audio file to transcribe.
+ *     model = Whisper model identifier.
+ *
+ * Default values such as JSON response format and temperature are taken from
+ * `TranscriptionRequest`.
+ *
+ * Returns: Request object usable with `OpenAIClient.transcription`.
+ */
 TranscriptionRequest transcriptionRequest(string file, string model)
 {
     auto request = TranscriptionRequest();
@@ -181,7 +203,16 @@ struct TranslationRequest
     double temperature = 0;
 }
 
-/// Convenience constructor for `TranslationRequest`.
+/**
+ * Convenience constructor for `TranslationRequest` objects used with the
+ * `/audio/translations` endpoint.
+ *
+ * Params:
+ *     file  = Path to the audio file to translate.
+ *     model = Whisper model identifier.
+ *
+ * Returns: Request object suitable for `OpenAIClient.translation`.
+ */
 TranslationRequest translationRequest(string file, string model)
 {
     auto request = TranslationRequest();

--- a/source/openai/chat.d
+++ b/source/openai/chat.d
@@ -715,7 +715,19 @@ version (none) unittest
 
     auto _ = deserializeJson!ChatCompletionResponse(errorJson);
 }
-///
+/**
+ * Helper to create a `ChatCompletionRequest` for the `/chat/completions`
+ * endpoint.
+ *
+ * Params:
+ *     model       = Chat model ID or deployment.
+ *     messages    = Sequence of chat messages to send.
+ *     maxTokens   = Maximum completion tokens (defaults to 16 in the
+ *                   request struct).
+ *     temperature = Sampling temperature (defaults to `1.0`).
+ *
+ * Returns: Request object consumable by `OpenAIClient.chatCompletion`.
+ */
 ChatCompletionRequest chatCompletionRequest(return scope string model, return scope ChatMessage[] messages, uint maxTokens, double temperature)
 {
     auto request = ChatCompletionRequest();

--- a/source/openai/completion.d
+++ b/source/openai/completion.d
@@ -83,7 +83,20 @@ struct CompletionRequest
     string user = null;
 }
 
-///
+/**
+ * Convenience helper that constructs a `CompletionRequest` for the
+ * `/completions` endpoint.
+ *
+ * Params:
+ *     model        = ID of the model or deployment.
+ *     prompt       = Text prompt sent to the model.
+ *     maxTokens    = Maximum tokens to generate (defaults to 16 in
+ *                    `CompletionRequest`).
+ *     temperature  = Sampling temperature (defaults to `1.0`).
+ *
+ * Returns: a populated request that can be passed to
+ *          `OpenAIClient.completion`.
+ */
 CompletionRequest completionRequest(string model, string prompt, uint maxTokens, double temperature)
 {
     auto request = CompletionRequest();

--- a/source/openai/embedding.d
+++ b/source/openai/embedding.d
@@ -38,7 +38,16 @@ struct EmbeddingRequest
     string user;
 }
 
-///
+/**
+ * Constructs an `EmbeddingRequest` for the `/embeddings` endpoint using a
+ * single input string.
+ *
+ * Params:
+ *     model = Embedding model identifier.
+ *     input = Text to embed.
+ *
+ * Returns: Request object for `OpenAIClient.embedding`.
+ */
 EmbeddingRequest embeddingRequest(string model, string input)
 {
     auto request = EmbeddingRequest();
@@ -60,7 +69,17 @@ unittest
         requestJson == `{"input":"Hello, D Programming Language!","model":"text-embedding-ada-002"}`);
 }
 
-///
+/**
+ * Constructs an `EmbeddingRequest` with a specified embedding dimension for the
+ * `/embeddings` endpoint.
+ *
+ * Params:
+ *     model      = Embedding model identifier.
+ *     input      = Text to embed.
+ *     dimensions = Size of the output vector.
+ *
+ * Returns: Request object for `OpenAIClient.embedding`.
+ */
 EmbeddingRequest embeddingRequest(string model, string input, uint dimensions)
 {
     auto request = EmbeddingRequest();
@@ -83,7 +102,16 @@ unittest
         requestJson == `{"input":"Hello, D Programming Language!","model":"text-embedding-3-small","dimensions":512}`);
 }
 
-///
+/**
+ * Creates an `EmbeddingRequest` for multiple input strings for the
+ * `/embeddings` endpoint.
+ *
+ * Params:
+ *     model  = Embedding model identifier.
+ *     inputs = Array of texts to embed.
+ *
+ * Returns: Request object for `OpenAIClient.embedding`.
+ */
 EmbeddingRequest embeddingRequest(string model, string[] inputs)
 {
     auto request = EmbeddingRequest();
@@ -106,7 +134,17 @@ unittest
         requestJson3 == `{"input":["Hello,","D","Programming","Language!"],"model":"text-embedding-ada-003"}`);
 }
 
-///
+/**
+ * Variant of `embeddingRequest` that allows specifying multiple inputs and the
+ * output vector size for the `/embeddings` endpoint.
+ *
+ * Params:
+ *     model      = Embedding model identifier.
+ *     inputs     = Array of texts to embed.
+ *     dimensions = Size of the output vector.
+ *
+ * Returns: Request object for `OpenAIClient.embedding`.
+ */
 EmbeddingRequest embeddingRequest(string model, string[] inputs, uint dimensions)
 {
     auto request = EmbeddingRequest();

--- a/source/openai/moderation.d
+++ b/source/openai/moderation.d
@@ -20,7 +20,15 @@ struct ModerationRequest
     string model;
 }
 
-///
+/**
+ * Convenience helper that populates a `ModerationRequest` for the
+ * `/moderations` endpoint.
+ *
+ * Params:
+ *     input = Text to be checked for policy violations.
+ *
+ * Returns: Request object for `OpenAIClient.moderation`.
+ */
 ModerationRequest moderationRequest(string input)
 {
     auto request = ModerationRequest();


### PR DESCRIPTION
## Summary
- add Ddoc comments for request helper constructors across modules
- record reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `dub build` in each example folder

------
https://chatgpt.com/codex/tasks/task_e_6848beccde7c832cbf5d83f7c215fd1d