### PR TITLE
[chat] document helper constructors

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -15,3 +15,18 @@
 <!-- reflection-template:end -->
 
 ## :memo: Reflection History
+<!-- reflection-template:start -->
+### :book: Reflection for 2025-06-10
+- **Task**: Update chat helpers documentation
+- **Objective**: Expand comments for message constructors and document `chatCompletionRequest` parameters.
+- **Outcome**: Added detailed doc comments and verified formatting, linting, tests, coverage and example builds.
+
+### :sparkles: What went well
+- Project tooling caught formatting issues automatically.
+
+### :warning: Pain points
+- Building all examples takes time due to compilation of dependencies.
+
+### :bulb: Proposed Improvement
+- Provide pre-built artifacts or a cached dependencies layer to speed up example builds.
+<!-- reflection-template:end -->

--- a/source/openai/chat.d
+++ b/source/openai/chat.d
@@ -200,13 +200,25 @@ struct ChatMessage
     }
 }
 
-///
+/**
+ * Convenience helper to construct a system role message.
+ *
+ * Params:
+ *     content - Text of the system prompt.
+ *     name    - Optional name associated with the message.
+ */
 ChatMessage systemChatMessage(string content, string name = null)
 {
     return ChatMessage("system", ChatMessageContent(content), name);
 }
 
-/// ditto
+/**
+ * Helper for building a `developer` role message.
+ *
+ * Params:
+ *     content - Developer instructions for the model.
+ *     name    - Optional name attached to the message.
+ */
 ChatMessage developerChatMessage(string content, string name = null)
 {
     return ChatMessage("developer", ChatMessageContent(content), name);
@@ -252,7 +264,13 @@ unittest
             message) == `{"role":"developer","content":"You are helpful AI assistant.","name":"ChatGPT"}`);
 }
 
-///
+/**
+ * Creates a user role chat message from a single string.
+ *
+ * Params:
+ *     content - The user's input text.
+ *     name    - Optional user name.
+ */
 ChatMessage userChatMessage(string content, string name = null)
 {
     return ChatMessage("user", ChatMessageContent(content), name);
@@ -715,7 +733,15 @@ version (none) unittest
 
     auto _ = deserializeJson!ChatCompletionResponse(errorJson);
 }
-///
+/**
+ * Convenience constructor for a `ChatCompletionRequest`.
+ *
+ * Params:
+ *     model       - Identifier of the model to use.
+ *     messages    - Ordered list of conversation messages to send.
+ *     maxTokens   - Limit for the completion part of the response.
+ *     temperature - Sampling temperature controlling randomness.
+ */
 ChatCompletionRequest chatCompletionRequest(return scope string model, return scope ChatMessage[] messages, uint maxTokens, double temperature)
 {
     auto request = ChatCompletionRequest();


### PR DESCRIPTION
## Summary
- expand docs for systemChatMessage, developerChatMessage and userChatMessage
- document the chatCompletionRequest helper
- add reflection entry

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `for d in examples/*; do if [ -d "$d" ]; then (cd "$d" && dub build); fi; done`

------
https://chatgpt.com/codex/tasks/task_e_6848bec99ed4832c940fd9b3d6622a50