### PR TITLE
[docs] update reflection guidelines

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -70,3 +70,17 @@
 
 ### :bulb: Proposed Improvement
 - Add a script to build all examples in parallel.
+### :book: Reflection for 2025-06-12
+- **Task**: Document reflection log guidelines
+- **Objective**: Prevent duplicate dates and maintain chronological order
+- **Outcome**: Updated AGENTS.md with instructions to deduplicate and append history properly
+
+### :sparkles: What went well
+- Simple documentation change required minimal code adjustments
+
+### :warning: Pain points
+- Running linter downloads dependencies each time, slowing down checks
+
+### :bulb: Proposed Improvement
+- Cache linter dependencies to speed up future runs
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,6 @@
 After completing your tasks, the agent **must append** one entry to `.agents/REFLECTION_HISTORY.md` using the exact `<!-- reflection-template:start --> … <!-- reflection-template:end -->` block that already exists in that file.
 
 > **One Bold Change rule**: every reflection must propose **exactly one** high-leverage improvement that could eliminate the biggest pain point next time.
+
+* Before appending, check `.agents/REFLECTION_HISTORY.md` for existing entries on the same date or with the same content and consolidate them to avoid duplication.
+* If earlier records are out of order or redundant, reorganize them so the newest reflection always appears at the bottom of the file.


### PR DESCRIPTION
## Summary
- mention deduplication rule for `REFLECTION_HISTORY.md`
- add a reflection entry for documenting the new guideline

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini --quiet`
- `dub test`
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_68497f07a160832c87b2d3d79b93257c