### PR TITLE
[ci] cache dub packages

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -84,3 +84,17 @@
 ### :bulb: Proposed Improvement
 - Cache linter dependencies to speed up future runs
 
+### :book: Reflection for 2025-06-11
+- **Task**: Cache Dub packages in CI
+- **Objective**: Speed up continuous integration by avoiding repeated downloads
+- **Outcome**: Added actions/cache steps to store `~/.dub/packages` on Linux and Windows
+
+### :sparkles: What went well
+- Workflow configuration was straightforward to extend
+
+### :warning: Pain points
+- Cross-platform paths for Dub packages required extra attention
+
+### :bulb: Proposed Improvement
+- Document recommended cache paths for different operating systems
+

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -18,6 +18,12 @@ jobs:
         uses: dlang-community/setup-dlang@v1
         with:
           compiler: ${{ matrix.dlang }}
+      - name: Cache Dub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.dub/packages
+          key: dub-${{ runner.os }}-${{ matrix.dlang }}-${{ hashFiles('dub.json') }}
+          restore-keys: dub-${{ runner.os }}-${{ matrix.dlang }}-
       - name: Build
         run: dub build --compiler=$DC
       - name: Lint
@@ -43,6 +49,12 @@ jobs:
         uses: dlang-community/setup-dlang@v1
         with:
           compiler: ${{ matrix.dlang }}
+      - name: Cache Dub packages
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.LOCALAPPDATA }}\dub\packages
+          key: dub-${{ runner.os }}-${{ matrix.dlang }}-${{ hashFiles('dub.json') }}
+          restore-keys: dub-${{ runner.os }}-${{ matrix.dlang }}-
       - name: Build
         run: dub build --compiler=$Env:DC
       - name: Lint


### PR DESCRIPTION
## Summary
- cache `~/.dub/packages` on Linux and Windows runners
- log reflection on caching improvement

## Testing
- `dub run dfmt -- source examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_684980de37f0832c9d042cd9b2320374