### PR TITLE
[scripts] build examples helper

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -84,3 +84,16 @@
 ### :bulb: Proposed Improvement
 - Cache linter dependencies to speed up future runs
 
+### :book: Reflection for 2025-06-13
+- **Task**: Add example build script
+- **Objective**: Speed up building numerous example projects
+- **Outcome**: Created `scripts/build_examples.sh` with fast and all modes and documented its usage in AGENTS.md. Verified formatting, linting, tests, coverage and builds.
+
+### :sparkles: What went well
+- The helper script compiles selected examples with one command.
+
+### :warning: Pain points
+- Sequential example builds remain time-consuming and parallel builds caused dub cache conflicts.
+
+### :bulb: Proposed Improvement
+- Investigate caching compiled dependencies or using `dub`'s built-in package cache to allow safe parallel builds.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,10 +68,13 @@
 1. Modify code.
 2. Run formatter and linter
 3. Run tests and coverage
-4. Build examples individually. Run `dub build` inside only the example folders you need. Build examples that:
-   * Have been modified in the commit,
-   * Depend on library modules that changed,
-   * Are needed for verifying new features.
+4. Build examples individually or use the helper script:
+   * Run `scripts/build_examples.sh fast` to compile only a small set of key examples.
+   * Run `scripts/build_examples.sh` (or `scripts/build_examples.sh all`) to build them all.
+   Building individually with `dub build` remains valid when touching only a few examples.
+   * Build examples that have been modified,
+     depend on changed library modules, or
+     are required for verifying new features.
    All examples should compile before major releases or when unsure.
 5. If all checks pass, commit changes and open a pull request.
 

--- a/scripts/build_examples.sh
+++ b/scripts/build_examples.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build OpenAI D examples
+# Usage: build_examples.sh [all|fast]
+#   all  - build every example project (default)
+#   fast - build a subset of key examples to save time
+
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+EXAMPLES_DIR="$SCRIPT_DIR/../examples"
+
+mode="${1:-all}"
+if [[ "$mode" != "all" && "$mode" != "fast" ]]; then
+    echo "Usage: $0 [all|fast]" >&2
+    exit 1
+fi
+
+cd "$EXAMPLES_DIR"
+
+fast_examples=(
+    chat
+    completion
+    embedding
+    moderation
+    responses
+)
+
+if [[ "$mode" == "all" ]]; then
+    mapfile -t targets < <(find . -maxdepth 1 -mindepth 1 -type d | sort)
+else
+    targets=("${fast_examples[@]}")
+fi
+
+for dir in "${targets[@]}"; do
+    echo "\n## Building $dir" >&2
+    (cd "$dir" && dub build)
+done


### PR DESCRIPTION
## Summary
- add `build_examples.sh` script to build examples sequentially
- document how to run the new script in `AGENTS.md`
- record reflection about the example build helper

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `./scripts/build_examples.sh fast`

------
https://chatgpt.com/codex/tasks/task_e_6849859f6908832c8bb2a65683956e55