### PR TITLE
[docs] adjust reflection template

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -4,13 +4,13 @@
   - **Objective**: [What was the goal of the task?]
   - **Outcome**: [What was the result of the task?]
 
-### :sparkles: What went well
+#### :sparkles: What went well
   - …
 
-### :warning: Pain points
+#### :warning: Pain points
   - …
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
   - …
 <!-- reflection-template:end -->
 
@@ -20,13 +20,13 @@
 - **Objective**: Expand comments for message constructors and document `chatCompletionRequest` parameters.
 - **Outcome**: Added detailed doc comments and verified formatting, linting, tests, coverage and example builds.
 
-### :sparkles: What went well
+#### :sparkles: What went well
 - Project tooling caught formatting issues automatically.
 
-### :warning: Pain points
+#### :warning: Pain points
 - Building all examples takes time due to compilation of dependencies.
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
 - Provide pre-built artifacts or a cached dependencies layer to speed up example builds.
 
 ### :book: Reflection for 2025-06-10
@@ -34,13 +34,13 @@
 - **Objective**: Improve library documentation clarity
 - **Outcome**: Added detailed descriptions to methods and ensured tests pass
 
-### :sparkles: What went well
+#### :sparkles: What went well
 - Tools made running formatter, linter and tests straightforward
 
-### :warning: Pain points
+#### :warning: Pain points
 - Building every example took a while due to dependency compilation
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
 - Provide pre-built artifacts or caching for example builds to speed up CI
 
 ### :book: Reflection for 2025-06-11
@@ -48,13 +48,13 @@
 - **Objective**: Clarify usage of helper constructors for OpenAI API requests
 - **Outcome**: Added Ddoc comments summarizing parameters and target endpoints
 
-### :sparkles: What went well
+#### :sparkles: What went well
 - Prebuilt examples compiled successfully after changes
 
-### :warning: Pain points
+#### :warning: Pain points
 - Compiling each example manually is repetitive
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
 - Provide a helper script to build all example projects in one step
 
 ### :book: Reflection for 2025-06-11
@@ -62,13 +62,13 @@
 - **Objective**: Match README style across examples
 - **Outcome**: Updated every example to use `new OpenAIClient()` and verified formatting, linting, tests, coverage, and builds.
 
-### :sparkles: What went well
+#### :sparkles: What went well
 - Tooling automated formatting and linting effectively.
 
-### :warning: Pain points
+#### :warning: Pain points
 - Building each example individually remains slow.
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
 - Add a script to build all examples in parallel.
 
 ### :book: Reflection for 2025-06-11
@@ -76,13 +76,13 @@
 - **Objective**: Prevent duplicate dates and maintain chronological order
 - **Outcome**: Updated AGENTS.md with instructions to deduplicate and append history properly
 
-### :sparkles: What went well
+#### :sparkles: What went well
 - Simple documentation change required minimal code adjustments
 
-### :warning: Pain points
+#### :warning: Pain points
 - Running linter downloads dependencies each time, slowing down checks
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
 - Cache linter dependencies to speed up future runs
 
 ### :book: Reflection for 2025-06-11
@@ -90,13 +90,13 @@
 - **Objective**: Speed up building numerous example projects
 - **Outcome**: Created `scripts/build_examples.sh` with fast and all modes and documented its usage in AGENTS.md. Verified formatting, linting, tests, coverage and builds.
 
-### :sparkles: What went well
+#### :sparkles: What went well
 - The helper script compiles selected examples with one command.
 
-### :warning: Pain points
+#### :warning: Pain points
 - Sequential example builds remain time-consuming and parallel builds caused dub cache conflicts.
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
 - Investigate caching compiled dependencies or using `dub`'s built-in package cache to allow safe parallel builds.
 
 ### :book: Reflection for 2025-06-11
@@ -104,13 +104,13 @@
 - **Objective**: Speed up continuous integration by avoiding repeated downloads
 - **Outcome**: Added actions/cache steps to store `~/.dub/packages` on Linux and Windows
 
-### :sparkles: What went well
+#### :sparkles: What went well
 - Workflow configuration was straightforward to extend
 
-### :warning: Pain points
+#### :warning: Pain points
 - Cross-platform paths for Dub packages required extra attention
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
 - Document recommended cache paths for different operating systems
 
 ### :book: Reflection for 2025-06-11 13:46
@@ -118,24 +118,38 @@
   - **Objective**: Avoid merge conflicts when multiple reflections occur on the same day
   - **Outcome**: Updated AGENTS instructions and template to include date and time
 
-### :sparkles: What went well
+#### :sparkles: What went well
   - Documentation change required minimal updates
 
-### :warning: Pain points
+#### :warning: Pain points
   - Running all checks still takes time even for small docs
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
   - Provide a lightweight documentation-only workflow to skip heavy builds
 ### :book: Reflection for 2025-06-11 14:52
   - **Task**: Adjust reflection formatting
   - **Objective**: Address reviewer comments to indent bullet lists and remove unnecessary tags
   - **Outcome**: Updated template and latest entry with proper list levels and cleaned tags
 
-### :sparkles: What went well
+#### :sparkles: What went well
   - Small edits quickly satisfied the formatting guidelines
 
-### :warning: Pain points
+#### :warning: Pain points
   - Running full builds for doc-only changes is still slow
 
-### :bulb: Proposed Improvement
+#### :bulb: Proposed Improvement
   - Introduce a docs-only workflow to speed up checks
+
+### :book: Reflection for 2025-06-12 10:54
+  - **Task**: Fix reflection header levels
+  - **Objective**: Clarify formatting blocks per reviewer comment
+  - **Outcome**: Updated template and history entries to use consistent section levels
+
+#### :sparkles: What went well
+  - Simple regex replace corrected headings quickly
+
+#### :warning: Pain points
+  - Waiting for full build cycle just to edit documentation
+
+#### :bulb: Proposed Improvement
+  - Add a linter rule to validate reflection headings automatically

--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -1,17 +1,17 @@
 <!-- reflection-template:start -->
-### :book: Reflection for [Date]
-- **Task**: [Task Name or Description]
-- **Objective**: [What was the goal of the task?]
-- **Outcome**: [What was the result of the task?]
+### :book: Reflection for [YYYY-MM-DD HH:MM]
+  - **Task**: [Task Name or Description]
+  - **Objective**: [What was the goal of the task?]
+  - **Outcome**: [What was the result of the task?]
 
 ### :sparkles: What went well
-- …
+  - …
 
 ### :warning: Pain points
-- …
+  - …
 
 ### :bulb: Proposed Improvement
-- …
+  - …
 <!-- reflection-template:end -->
 
 ## :memo: Reflection History
@@ -112,3 +112,30 @@
 
 ### :bulb: Proposed Improvement
 - Document recommended cache paths for different operating systems
+
+### :book: Reflection for 2025-06-11 13:46
+  - **Task**: Add timestamp to reflection history template
+  - **Objective**: Avoid merge conflicts when multiple reflections occur on the same day
+  - **Outcome**: Updated AGENTS instructions and template to include date and time
+
+### :sparkles: What went well
+  - Documentation change required minimal updates
+
+### :warning: Pain points
+  - Running all checks still takes time even for small docs
+
+### :bulb: Proposed Improvement
+  - Provide a lightweight documentation-only workflow to skip heavy builds
+### :book: Reflection for 2025-06-11 14:52
+  - **Task**: Adjust reflection formatting
+  - **Objective**: Address reviewer comments to indent bullet lists and remove unnecessary tags
+  - **Outcome**: Updated template and latest entry with proper list levels and cleaned tags
+
+### :sparkles: What went well
+  - Small edits quickly satisfied the formatting guidelines
+
+### :warning: Pain points
+  - Running full builds for doc-only changes is still slow
+
+### :bulb: Proposed Improvement
+  - Introduce a docs-only workflow to speed up checks

--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -16,102 +16,102 @@
 
 ## :memo: Reflection History
 ### :book: Reflection for 2025-06-10
-- **Task**: Update chat helpers documentation
-- **Objective**: Expand comments for message constructors and document `chatCompletionRequest` parameters.
-- **Outcome**: Added detailed doc comments and verified formatting, linting, tests, coverage and example builds.
+  - **Task**: Update chat helpers documentation
+  - **Objective**: Expand comments for message constructors and document `chatCompletionRequest` parameters.
+  - **Outcome**: Added detailed doc comments and verified formatting, linting, tests, coverage and example builds.
 
 #### :sparkles: What went well
-- Project tooling caught formatting issues automatically.
+  - Project tooling caught formatting issues automatically.
 
 #### :warning: Pain points
-- Building all examples takes time due to compilation of dependencies.
+  - Building all examples takes time due to compilation of dependencies.
 
 #### :bulb: Proposed Improvement
-- Provide pre-built artifacts or a cached dependencies layer to speed up example builds.
+  - Provide pre-built artifacts or a cached dependencies layer to speed up example builds.
 
 ### :book: Reflection for 2025-06-10
-- **Task**: Add doc comments for configuration and API methods
-- **Objective**: Improve library documentation clarity
-- **Outcome**: Added detailed descriptions to methods and ensured tests pass
+  - **Task**: Add doc comments for configuration and API methods
+  - **Objective**: Improve library documentation clarity
+  - **Outcome**: Added detailed descriptions to methods and ensured tests pass
 
 #### :sparkles: What went well
-- Tools made running formatter, linter and tests straightforward
+  - Tools made running formatter, linter and tests straightforward
 
 #### :warning: Pain points
-- Building every example took a while due to dependency compilation
+  - Building every example took a while due to dependency compilation
 
 #### :bulb: Proposed Improvement
-- Provide pre-built artifacts or caching for example builds to speed up CI
+  - Provide pre-built artifacts or caching for example builds to speed up CI
 
 ### :book: Reflection for 2025-06-11
-- **Task**: Document request helper functions
-- **Objective**: Clarify usage of helper constructors for OpenAI API requests
-- **Outcome**: Added Ddoc comments summarizing parameters and target endpoints
+  - **Task**: Document request helper functions
+  - **Objective**: Clarify usage of helper constructors for OpenAI API requests
+  - **Outcome**: Added Ddoc comments summarizing parameters and target endpoints
 
 #### :sparkles: What went well
-- Prebuilt examples compiled successfully after changes
+  - Prebuilt examples compiled successfully after changes
 
 #### :warning: Pain points
-- Compiling each example manually is repetitive
+  - Compiling each example manually is repetitive
 
 #### :bulb: Proposed Improvement
-- Provide a helper script to build all example projects in one step
+  - Provide a helper script to build all example projects in one step
 
 ### :book: Reflection for 2025-06-11
-- **Task**: Replace new `OpenAIClient` style
-- **Objective**: Match README style across examples
-- **Outcome**: Updated every example to use `new OpenAIClient()` and verified formatting, linting, tests, coverage, and builds.
+  - **Task**: Replace new `OpenAIClient` style
+  - **Objective**: Match README style across examples
+  - **Outcome**: Updated every example to use `new OpenAIClient()` and verified formatting, linting, tests, coverage, and builds.
 
 #### :sparkles: What went well
-- Tooling automated formatting and linting effectively.
+  - Tooling automated formatting and linting effectively.
 
 #### :warning: Pain points
-- Building each example individually remains slow.
+  - Building each example individually remains slow.
 
 #### :bulb: Proposed Improvement
-- Add a script to build all examples in parallel.
+  - Add a script to build all examples in parallel.
 
 ### :book: Reflection for 2025-06-11
-- **Task**: Document reflection log guidelines
-- **Objective**: Prevent duplicate dates and maintain chronological order
-- **Outcome**: Updated AGENTS.md with instructions to deduplicate and append history properly
+  - **Task**: Document reflection log guidelines
+  - **Objective**: Prevent duplicate dates and maintain chronological order
+  - **Outcome**: Updated AGENTS.md with instructions to deduplicate and append history properly
 
 #### :sparkles: What went well
-- Simple documentation change required minimal code adjustments
+  - Simple documentation change required minimal code adjustments
 
 #### :warning: Pain points
-- Running linter downloads dependencies each time, slowing down checks
+  - Running linter downloads dependencies each time, slowing down checks
 
 #### :bulb: Proposed Improvement
-- Cache linter dependencies to speed up future runs
+  - Cache linter dependencies to speed up future runs
 
 ### :book: Reflection for 2025-06-11
-- **Task**: Add example build script
-- **Objective**: Speed up building numerous example projects
-- **Outcome**: Created `scripts/build_examples.sh` with fast and all modes and documented its usage in AGENTS.md. Verified formatting, linting, tests, coverage and builds.
+  - **Task**: Add example build script
+  - **Objective**: Speed up building numerous example projects
+  - **Outcome**: Created `scripts/build_examples.sh` with fast and all modes and documented its usage in AGENTS.md. Verified formatting, linting, tests, coverage and builds.
 
 #### :sparkles: What went well
-- The helper script compiles selected examples with one command.
+  - The helper script compiles selected examples with one command.
 
 #### :warning: Pain points
-- Sequential example builds remain time-consuming and parallel builds caused dub cache conflicts.
+  - Sequential example builds remain time-consuming and parallel builds caused dub cache conflicts.
 
 #### :bulb: Proposed Improvement
-- Investigate caching compiled dependencies or using `dub`'s built-in package cache to allow safe parallel builds.
+  - Investigate caching compiled dependencies or using `dub`'s built-in package cache to allow safe parallel builds.
 
 ### :book: Reflection for 2025-06-11
-- **Task**: Cache Dub packages in CI
-- **Objective**: Speed up continuous integration by avoiding repeated downloads
-- **Outcome**: Added actions/cache steps to store `~/.dub/packages` on Linux and Windows
+  - **Task**: Cache Dub packages in CI
+  - **Objective**: Speed up continuous integration by avoiding repeated downloads
+  - **Outcome**: Added actions/cache steps to store `~/.dub/packages` on Linux and Windows
 
 #### :sparkles: What went well
-- Workflow configuration was straightforward to extend
+  - Workflow configuration was straightforward to extend
 
 #### :warning: Pain points
-- Cross-platform paths for Dub packages required extra attention
+  - Cross-platform paths for Dub packages required extra attention
 
 #### :bulb: Proposed Improvement
-- Document recommended cache paths for different operating systems
+  - Document recommended cache paths for different operating systems
 
 ### :book: Reflection for 2025-06-11 13:46
   - **Task**: Add timestamp to reflection history template

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,5 +102,6 @@ After completing your tasks, the agent **must append** one entry to `.agents/REF
 
 > **One Bold Change rule**: every reflection must propose **exactly one** high-leverage improvement that could eliminate the biggest pain point next time.
 
-* Before appending, check `.agents/REFLECTION_HISTORY.md` for existing entries on the same date or with the same content and consolidate them to avoid duplication.
+* Records are keyed by timestamp (to the minute) to avoid collisions. Specify the current date and time as `YYYY-MM-DD HH:MM` when filling in the template.
+* Before appending, check `.agents/REFLECTION_HISTORY.md` for existing entries with the same timestamp or identical content and consolidate them to avoid duplication.
 * If earlier records are out of order or redundant, reorganize them so the newest reflection always appears at the bottom of the file.


### PR DESCRIPTION
## Summary
- indent bullet items in reflection template
- remove extraneous template tags from the latest entry
- log today's formatting adjustment with timestamp

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_6849887371bc832c9fd0a19b523e714f