### PR TITLE
[clients] allow empty OPENAI_API_BASE to use default

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -112,3 +112,17 @@
 
 ### :bulb: Proposed Improvement
 - Document recommended cache paths for different operating systems
+
+### :book: Reflection for 2025-06-12
+- **Task**: Update environment variable handling
+- **Objective**: Ensure OPENAI_API_BASE uses default URL when unset or empty
+- **Outcome**: Changed configuration to use `environment.get(envApiBaseName, "")` and kept default fallback. Verified formatting, linting, tests, coverage and example builds.
+
+### :sparkles: What went well
+- Tooling caught no issues after modification, making validation quick.
+
+### :warning: Pain points
+- Coverage files clutter the project root and are easy to forget to clean.
+
+### :bulb: Proposed Improvement
+- Automate cleanup of coverage artifacts after tests

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -124,7 +124,7 @@ class OpenAIClientConfig
 
         auto envApiKey = environment.get(envApiKeyName, "");
         auto envOrganization = environment.get(envOrgName, "");
-        auto envApiBase = environment.get(envApiBaseName, "https://api.openai.com/v1");
+        auto envApiBase = environment.get(envApiBaseName, "");
         auto envDeploymentId = environment.get(envDeploymentName, "");
         auto envApiVersion = environment.get(envApiVersionName, "");
 


### PR DESCRIPTION
## Summary
- default OPENAI_API_BASE even when variable is empty
- add reflection entry for today's work

## Testing
- `dub run dfmt -- source`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684ab38083b0832c9b0d8b54c7ef233f