### PR TITLE
[responses] make metadata optional

### DIFF
--- a/.agents/REFLECTION_HISTORY.md
+++ b/.agents/REFLECTION_HISTORY.md
@@ -112,3 +112,17 @@
 
 ### :bulb: Proposed Improvement
 - Document recommended cache paths for different operating systems
+
+### :book: Reflection for 2025-06-12
+- **Task**: Make metadata optional in responses
+- **Objective**: Ensure API structs support optional metadata fields
+- **Outcome**: Added `@serdeOptional` attribute, updated formatting, linting, tests, coverage and example builds
+
+### :sparkles: What went well
+- Toolchain handled formatting and building examples reliably
+
+### :warning: Pain points
+- Coverage files clutter the repo root and are hard to review
+
+### :bulb: Proposed Improvement
+- Provide a script to summarize coverage results and clean up old lst files

--- a/source/openai/responses.d
+++ b/source/openai/responses.d
@@ -240,7 +240,7 @@ struct ResponsesResponse
     string truncation;
     ResponseUsage usage;
     string user;
-    StringMap!string metadata;
+    @serdeOptional @serdeIgnoreDefault StringMap!string metadata;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `ResponsesResponse.metadata` field optional
- record reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `./scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684ab3873bdc832cb18a66a985b4d406