### PR TITLE
[common] fix temperature unit typos

### DIFF
--- a/.agents/reflections/2025-06-12-1334-fix-temp-unit-spelling.md
+++ b/.agents/reflections/2025-06-12-1334-fix-temp-unit-spelling.md
@@ -1,0 +1,16 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 13:34]
+  - **Task**: Correct temperature unit typos
+  - **Objective**: Replace misspelled "celcius" and "farenheit" in JSON schema examples and run checks
+  - **Outcome**: Spelling fixed and all checks passed
+
+#### :sparkles: What went well
+  - Straightforward text changes made quickly
+  - Formatter, linter, and tests all ran without issues
+
+#### :warning: Pain points
+  - Running coverage and linter fetches many dependencies each time, which slows feedback
+
+#### :bulb: Proposed Improvement
+  - Add a script to set up and cache D dependencies between tasks to speed up lint and coverage runs
+<!-- reflection-template:end -->

--- a/source/openai/common.d
+++ b/source/openai/common.d
@@ -452,7 +452,7 @@ unittest
         [
         "location": JsonSchema.string_("The city and state, e.g. San Francisco, CA"),
         "format": JsonSchema.string_("The temperature unit to use. Infer this from the users location.", [
-            "celcius", "farenheit"
+            "celsius", "fahrenheit"
         ])
     ], ["location", "format"]);
 }
@@ -489,7 +489,7 @@ unittest
         [
         "location": JsonSchema.string_("The city and state, e.g. San Francisco, CA"),
         "format": JsonSchema.string_("The temperature unit to use. Infer this from the users location.", [
-            "celcius", "farenheit"
+            "celsius", "fahrenheit"
         ]),
         "num_days": JsonSchema.integer_("The number of days to forecast"),
     ], ["location", "format", "num_days"]);


### PR DESCRIPTION
## Summary
- fix spelling of temperature units in JSON schema examples
- add reflection entry

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_684ad6cd7ed4832c8665ac771141ecdb