### PR TITLE
[client] clarify chunked file test

### DIFF
--- a/.agents/reflections/2025-06-12-1336-stream-audio-chunks.md
+++ b/.agents/reflections/2025-06-12-1336-stream-audio-chunks.md
@@ -1,0 +1,16 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 13:36]
+  - **Task**: Stream file chunks in audio methods
+  - **Objective**: Use File.byChunk so large audio files don't load fully in memory
+  - **Outcome**: Updated transcription and translation to append chunks. Tests and builds pass.
+
+#### :sparkles: What went well
+  - D's byChunk API was straightforward to integrate
+
+#### :warning: Pain points
+  - Running dub tools takes significant time due to dependencies
+
+#### :bulb: Proposed Improvement
+  - Automate dependency caching in CI to speed up lint/test steps
+<!-- reflection-template:end -->
+

--- a/.agents/reflections/2025-06-12-1349-refactor-chunk-method-for-testability.md
+++ b/.agents/reflections/2025-06-12-1349-refactor-chunk-method-for-testability.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 13:49]
+  - **Task**: Refactor streaming audio methods for testability
+  - **Objective**: Extract chunked file logic into a private method and add unit tests
+  - **Outcome**: Added `appendFileChunked` helper with accompanying unittest
+
+#### :sparkles: What went well
+  - Reused existing style for private method tests
+
+#### :warning: Pain points
+  - Verifying streaming behavior required extra setup with temp files
+
+#### :bulb: Proposed Improvement
+  - Introduce helpers for creating temporary test resources
+<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2044-clarify-chunked-test.md
+++ b/.agents/reflections/2025-06-12-2044-clarify-chunked-test.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 20:44]
+  - **Task**: Clarify chunked upload unit test
+  - **Objective**: Remove dynamic filename from expected string and use explicit value
+  - **Outcome**: Updated unittest with static filename constant; all checks continue to pass
+
+#### :sparkles: What went well
+  - Changing test expectations was straightforward
+
+#### :warning: Pain points
+  - Running dfmt and dub tools takes time as dependencies build
+
+#### :bulb: Proposed Improvement
+  - Cache formatted binaries to avoid repeated compilation in CI
+<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2134-deduplicate-file-import.md
+++ b/.agents/reflections/2025-06-12-2134-deduplicate-file-import.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 21:34]
+  - **Task**: Address review comment
+  - **Objective**: Remove duplicate File imports across audio methods
+  - **Outcome**: Moved `import std.stdio : File;` to module level and cleaned up local imports
+
+#### :sparkles: What went well
+  - Code cleanup was straightforward
+
+#### :warning: Pain points
+  - Rebuilding dfmt each run slows down the workflow
+
+#### :bulb: Proposed Improvement
+  - Cache dfmt binaries between runs to speed up formatting
+<!-- reflection-template:end -->

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -8,6 +8,7 @@ import mir.ser.json;
 import std.net.curl;
 import std.algorithm.iteration : joiner;
 import std.array : array, Appender;
+import std.stdio : File;
 
 import openai.chat;
 import openai.completion;
@@ -382,7 +383,6 @@ class OpenAIClient
         import std.conv : to;
         import std.path : baseName;
         import std.random : uniform;
-        import std.stdio : File;
 
         auto http = HTTP();
         setupHttpByConfig(http);
@@ -452,7 +452,6 @@ class OpenAIClient
         import std.conv : to;
         import std.path : baseName;
         import std.random : uniform;
-        import std.stdio : File;
 
         auto http = HTTP();
         setupHttpByConfig(http);
@@ -621,7 +620,6 @@ class OpenAIClient
         string filePath) @system
     {
         import std.path : baseName;
-        import std.stdio : File;
 
         body.put(cast(ubyte[])("--" ~ boundary ~ "\r\n"));
         body.put(cast(ubyte[])(


### PR DESCRIPTION
## Summary
- use static filename in `appendFileChunked` unittest to clarify multipart expectation
- record the update in a new reflection entry

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684ad6e5fe60832c8e7adf7652287099