### PR TITLE
[openai] remove unused import

### DIFF
--- a/.agents/reflections/2025-06-12-2107-remove-unused-import.md
+++ b/.agents/reflections/2025-06-12-2107-remove-unused-import.md
@@ -1,0 +1,16 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 21:07]
+  - **Task**: Clean up unused import in setupHttpByConfig
+  - **Objective**: Remove the unnecessary `canFind` import and ensure compilation passes
+  - **Outcome**: The import was deleted and tests still pass
+
+#### :sparkles: What went well
+  - Simple code cleanup with clear instructions
+
+#### :warning: Pain points
+  - Accidentally removed another import during sed, causing a compile error which required an extra fix
+
+#### :bulb: Proposed Improvement
+  - Implement a pre-commit script that scans for compilation errors before running full test suite to catch mistakes earlier
+<!-- reflection-template:end -->
+

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -588,7 +588,6 @@ class OpenAIClient
 
     private void setupHttpByConfig(scope ref HTTP http) @system
     {
-        import std.algorithm.searching : canFind;
 
         if (config.isAzure)
         {


### PR DESCRIPTION
## Summary
- remove `canFind` import from `setupHttpByConfig`
- add reflection entry

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684b4096ed10832c80aace6eaeb2122a