### PR TITLE
[chat] remove leftover doc comment

### DIFF
--- a/.agents/reflections/2025-06-12-2056-comment-chat-store-member.md
+++ b/.agents/reflections/2025-06-12-2056-comment-chat-store-member.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 20:56]
+  - **Task**: Comment out store member in chat.d and adjust docs/tests
+  - **Objective**: Remove usage of store parameter per OpenAI data policy
+  - **Outcome**: Store field commented out, code formatted, linted and tests pass
+
+#### :sparkles: What went well
+  - Straightforward change, tests already covered serialization without store
+
+#### :warning: Pain points
+  - Running dfmt and dscanner takes time due to dependencies
+
+#### :bulb: Proposed Improvement
+  - Provide cached binaries for dfmt/dscanner to speed up CI and local runs
+<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2105-remove-chat-store-doc-comment.md
+++ b/.agents/reflections/2025-06-12-2105-remove-chat-store-doc-comment.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 21:05]
+  - **Task**: Remove stray doc comment when commenting out store
+  - **Objective**: Ensure no misleading documentation remains for the disabled store parameter
+  - **Outcome**: Doc comment removed, code reformatted and all checks pass
+
+#### :sparkles: What went well
+  - Clear reviewer feedback made the fix simple
+
+#### :warning: Pain points
+  - Long build times for examples and linter due to dependency compilation
+
+#### :bulb: Proposed Improvement
+  - Cache compiled versions of dfmt and dscanner tools to speed up workflows
+<!-- reflection-template:end -->

--- a/source/openai/chat.d
+++ b/source/openai/chat.d
@@ -469,9 +469,8 @@ struct ChatCompletionRequest
     ///
     ChatMessage[] messages;
 
-    ///
-    @serdeIgnoreDefault
-    string store;
+    //@serdeIgnoreDefault
+    //string store; /// disabled, see https://platform.openai.com/docs/guides/your-data
 
     /// Use `ReasoningEffortLow`, `ReasoningEffortMedium` or `ReasoningEffortHigh`.
     @serdeIgnoreDefault


### PR DESCRIPTION
## Summary
- remove stray doc comment on the disabled `store` field
- document the change in today's reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `./scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684b3e3986d4832cb3cae445c6124fa5