### PR TITLE
[openai] cast include values to string

### DIFF
--- a/.agents/reflections/2025-06-12-2119-cast-include-values.md
+++ b/.agents/reflections/2025-06-12-2119-cast-include-values.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 21:19]
+  - **Task**: Replace to!string with cast(string) in listInputItems
+  - **Objective**: Ensure include values are cast directly without to!string
+  - **Outcome**: Modified openai.d and passed formatting, linting, tests and coverage
+
+#### :sparkles: What went well
+  - Smooth build and test workflow
+
+#### :warning: Pain points
+  - Compiling examples produced unwanted artifacts that required cleanup
+
+#### :bulb: Proposed Improvement
+  - Add a clean step in build scripts to remove generated binaries automatically
+<!-- reflection-template:end -->

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -565,7 +565,6 @@ class OpenAIClient
 
         import std.string : format;
         import std.algorithm : map;
-        import std.conv : to;
 
         string url = buildUrl("/responses/" ~ request.responseId ~ "/input_items");
         string sep = "?";
@@ -579,7 +578,7 @@ class OpenAIClient
             url ~= format("%sbefore=%s", sep, request.before), sep = "&";
         if (request.include !is null && request.include.length)
             url ~= format("%sinclude=%s", sep,
-                cast(string) request.include.map!(x => to!string(x)).joiner(",").array);
+                request.include.map!(x => cast(string) x).joiner(",").array);
 
         auto content = cast(char[]) get!(HTTP, ubyte)(url, http);
         auto result = content.deserializeJson!ResponseItemList();


### PR DESCRIPTION
## Summary
- cast enum values directly to string in `listInputItems`
- add corresponding reflection entry

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684b43ac1840832c80781e3e0afc06da