### PR TITLE
[chat] strip trailing newline in aggregated text

### DIFF
--- a/.agents/reflections/2025-06-12-2254-strip-trailing-newline.md
+++ b/.agents/reflections/2025-06-12-2254-strip-trailing-newline.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 22:54]
+  - **Task**: Remove trailing newline in chat message text
+  - **Objective**: Ensure `getAllTextContent` returns text without a newline suffix
+  - **Outcome**: Updated implementation and added unittest; all checks pass
+
+#### :sparkles: What went well
+  - Changes were small and unit tests provided quick feedback
+
+#### :warning: Pain points
+  - Local build of example binaries pulled dependencies again, slowing the workflow
+
+#### :bulb: Proposed Improvement
+  - Add a make target to clean example build artifacts automatically
+<!-- reflection-template:end -->

--- a/source/openai/chat.d
+++ b/source/openai/chat.d
@@ -196,7 +196,9 @@ struct ChatMessage
         );
         // dfmt on
 
-        return appender.data;
+        import std.string : stripRight;
+
+        return appender.data.stripRight("\n");
     }
 }
 
@@ -311,6 +313,18 @@ unittest
 
     assert(serializeJson(
             message) == `{"role":"user","content":"How does this work?","name":"User123"}`);
+}
+
+unittest
+{
+    auto message = userChatMessage("Hello");
+
+    auto text = message.getAllTextContent();
+
+    import std.algorithm.searching : endsWith;
+
+    assert(text == "Hello");
+    assert(!text.endsWith("\n"));
 }
 
 ///


### PR DESCRIPTION
## Summary
- remove trailing newline from `getAllTextContent`
- verify returned text has no newline suffix
- add reflection entry

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `./scripts/build_examples.sh fast`

------
https://chatgpt.com/codex/tasks/task_e_684b59ac71c8832cb701cfb4c1e8c70b