### PR TITLE
[openai] handle empty pagination params

### DIFF
--- a/.agents/reflections/2025-06-12-2255-handle-empty-pagination.md
+++ b/.agents/reflections/2025-06-12-2255-handle-empty-pagination.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 22:55]
+  - **Task**: Update pagination params and tests
+  - **Objective**: Ensure query parameters are omitted when empty and maintain coverage
+  - **Outcome**: Added helper method and new unittest to verify URL building
+
+#### :sparkles: What went well
+  - Test suite and examples built without issues
+
+#### :warning: Pain points
+  - Local build of examples required fetching dependencies, slowing execution
+
+#### :bulb: Proposed Improvement
+  - Cache Dub dependencies to speed up example builds
+<!-- reflection-template:end -->


### PR DESCRIPTION
## Summary
- skip empty `after` and `before` params when listing input items
- expose helper to build list-input-items URLs
- test that empty values don't appear in query params
- add reflection file

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684b59d1d400832c918022d0febd2e55