### PR TITLE
[images] add Images API

### DIFF
--- a/.agents/reflections/2025-06-12-2345-images-api.md
+++ b/.agents/reflections/2025-06-12-2345-images-api.md
@@ -1,0 +1,16 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 23:45]
+  - **Task**: Implement Images API
+  - **Objective**: Add image generation support with enums, client methods, examples and docs
+  - **Outcome**: Added new module, client functions, example program, tests and documentation
+
+#### :sparkles: What went well
+  - OpenAPI spec helped confirm request fields
+  - Tests, formatter and linter ran without issues
+
+#### :warning: Pain points
+  - Local lint step downloaded dependencies each run which was slow
+
+#### :bulb: Proposed Improvement
+  - Cache dscanner in CI to speed up lint executions
+<!-- reflection-template:end -->

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [x] speech
   - [x] transcription
   - [x] translations
-- [ ] [Images](https://platform.openai.com/docs/api-reference/images) (TODO)
+  - [x] [Images](https://platform.openai.com/docs/api-reference/images)
 - [x] [Embeddings](https://platform.openai.com/docs/api-reference/embeddings)
 - [ ] [Evals](https://platform.openai.com/docs/api-reference/evals) (TODO)
 - [ ] [Fine-tunings](https://platform.openai.com/docs/api-reference/fine-tuning) (TODO)
@@ -202,6 +202,24 @@ writeln(response.text);
 ```
 
 See `examples/audio_translation` for a complete example.
+
+__Images__
+
+```d name=images
+import std;
+import openai;
+
+// Load API key from environment variable
+auto client = new OpenAIClient();
+
+// POST /images/generations
+auto request = imageGenerationRequest("A cute baby sea otter");
+request.responseFormat = ImageResponseFormatB64Json;
+auto response = client.imageGeneration(request);
+write("image.png", Base64.decode(response.data[0].b64Json));
+```
+
+See `examples/images` for a complete example.
 
 ## OpenAIClientConfig
 

--- a/examples/images/dub.sdl
+++ b/examples/images/dub.sdl
@@ -1,0 +1,6 @@
+name "images"
+description "Generate images using OpenAI"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/images/source/app.d
+++ b/examples/images/source/app.d
@@ -1,0 +1,18 @@
+import std.stdio;
+import std.file : write;
+import std.base64;
+
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    auto request = imageGenerationRequest("A cute baby sea otter");
+    request.responseFormat = ImageResponseFormatB64Json;
+
+    auto response = client.imageGeneration(request);
+    auto bytes = Base64.decode(response.data[0].b64Json);
+    write("image.png", bytes);
+    writeln("saved image.png: ", bytes.length, " bytes");
+}

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -16,6 +16,7 @@ import openai.embedding;
 import openai.models;
 import openai.moderation;
 import openai.audio;
+import openai.images;
 import openai.responses;
 
 @safe:
@@ -494,6 +495,129 @@ class OpenAIClient
         return text.deserializeJson!AudioTextResponse();
     }
 
+    /// Generate an image via `/images/generations`.
+    ImageResponse imageGeneration(in ImageGenerationRequest request) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (request.prompt.length > 0)
+    {
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+        http.addRequestHeader("Content-Type", "application/json");
+
+        auto requestJson = serializeJson(request);
+        auto content = cast(char[]) post!ubyte(buildUrl("/images/generations"), requestJson, http);
+
+        auto result = content.deserializeJson!ImageResponse();
+        return result;
+    }
+
+    /// Edit an image via `/images/edits`.
+    ImageResponse imageEdit(in ImageEditRequest request) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (request.image.length > 0)
+    in (request.prompt.length > 0)
+    {
+        import std.array : appender;
+        import std.conv : to;
+        import std.random : uniform;
+
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+
+        auto boundary = "--------------------------" ~ to!string(uniform(0, int.max));
+        http.addRequestHeader("Content-Type", "multipart/form-data; boundary=" ~ boundary);
+
+        auto body = appender!(ubyte[])();
+
+        void addText(string name, string value)
+        {
+            body.put(cast(ubyte[])("--" ~ boundary ~ "\r\n"));
+            body.put(cast(ubyte[])("Content-Disposition: form-data; name=\"" ~ name ~ "\"\r\n\r\n"));
+            body.put(cast(ubyte[]) value);
+            body.put(cast(ubyte[]) "\r\n");
+        }
+
+        void addFile(string name, string filePath)
+        {
+            appendFileChunked(body, boundary, name, filePath);
+        }
+
+        addFile("image", request.image);
+        if (request.mask.length)
+            addFile("mask", request.mask);
+        addText("prompt", request.prompt);
+        if (request.model.length)
+            addText("model", request.model);
+        if (request.n != 0)
+            addText("n", to!string(request.n));
+        if (request.size.length)
+            addText("size", request.size);
+        if (request.responseFormat.length)
+            addText("response_format", request.responseFormat);
+        if (request.user.length)
+            addText("user", request.user);
+
+        body.put(cast(ubyte[])("--" ~ boundary ~ "--\r\n"));
+
+        auto content = cast(char[]) post!ubyte(buildUrl("/images/edits"), body.data, http);
+
+        auto result = content.deserializeJson!ImageResponse();
+        return result;
+    }
+
+    /// Create image variations via `/images/variations`.
+    ImageResponse imageVariation(in ImageVariationRequest request) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (request.image.length > 0)
+    {
+        import std.array : appender;
+        import std.conv : to;
+        import std.random : uniform;
+
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+
+        auto boundary = "--------------------------" ~ to!string(uniform(0, int.max));
+        http.addRequestHeader("Content-Type", "multipart/form-data; boundary=" ~ boundary);
+
+        auto body = appender!(ubyte[])();
+
+        void addText(string name, string value)
+        {
+            body.put(cast(ubyte[])("--" ~ boundary ~ "\r\n"));
+            body.put(cast(ubyte[])("Content-Disposition: form-data; name=\"" ~ name ~ "\"\r\n\r\n"));
+            body.put(cast(ubyte[]) value);
+            body.put(cast(ubyte[]) "\r\n");
+        }
+
+        void addFile(string name, string filePath)
+        {
+            appendFileChunked(body, boundary, name, filePath);
+        }
+
+        addFile("image", request.image);
+        if (request.model.length)
+            addText("model", request.model);
+        if (request.n != 0)
+            addText("n", to!string(request.n));
+        if (request.size.length)
+            addText("size", request.size);
+        if (request.responseFormat.length)
+            addText("response_format", request.responseFormat);
+        if (request.user.length)
+            addText("user", request.user);
+
+        body.put(cast(ubyte[])("--" ~ boundary ~ "--\r\n"));
+
+        auto content = cast(char[]) post!ubyte(buildUrl("/images/variations"), body.data, http);
+
+        auto result = content.deserializeJson!ImageResponse();
+        return result;
+    }
+
     ///
     ResponsesResponse createResponse(in CreateResponseRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
@@ -563,8 +687,7 @@ class OpenAIClient
             url ~= format("%safter=%s", sep, request.after), sep = "&";
         if (request.before !is null)
             url ~= format("%sbefore=%s", sep, request.before), sep = "&";
-        if (request.include !is null && request.include.length)
-            // Cast enum values to strings to ensure proper serialization into query parameters.
+        if (request.include !is null && request.include.length) // Cast enum values to strings to ensure proper serialization into query parameters.
             url ~= format("%sinclude=%s", sep,
                 request.include.map!(x => cast(string) x).joiner(",").array);
 
@@ -743,6 +866,75 @@ class OpenAIClient
         auto client = new OpenAIClient(cfg);
         assert(client.buildUrl("/audio/speech") ==
                 "https://westus.api.cognitive.microsoft.com/openai/deployments/dep/audio/speech?api-version=2024-05-01");
+    }
+
+    @("buildUrl image generation - openai")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/images/generations") ==
+                "https://api.openai.com/v1/images/generations");
+    }
+
+    @("buildUrl image generation - azure")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        cfg.apiBase = "https://westus.api.cognitive.microsoft.com";
+        cfg.deploymentId = "dep";
+        cfg.apiVersion = "2024-05-01";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/images/generations") ==
+                "https://westus.api.cognitive.microsoft.com/openai/deployments/dep/images/generations?api-version=2024-05-01");
+    }
+
+    @("buildUrl image edit - openai")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/images/edits") ==
+                "https://api.openai.com/v1/images/edits");
+    }
+
+    @("buildUrl image edit - azure")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        cfg.apiBase = "https://westus.api.cognitive.microsoft.com";
+        cfg.deploymentId = "dep";
+        cfg.apiVersion = "2024-05-01";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/images/edits") ==
+                "https://westus.api.cognitive.microsoft.com/openai/deployments/dep/images/edits?api-version=2024-05-01");
+    }
+
+    @("buildUrl image variation - openai")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/images/variations") ==
+                "https://api.openai.com/v1/images/variations");
+    }
+
+    @("buildUrl image variation - azure")
+    unittest
+    {
+        auto cfg = new OpenAIClientConfig;
+        cfg.apiKey = "k";
+        cfg.apiBase = "https://westus.api.cognitive.microsoft.com";
+        cfg.deploymentId = "dep";
+        cfg.apiVersion = "2024-05-01";
+        auto client = new OpenAIClient(cfg);
+        assert(client.buildUrl("/images/variations") ==
+                "https://westus.api.cognitive.microsoft.com/openai/deployments/dep/images/variations?api-version=2024-05-01");
     }
 }
 

--- a/source/openai/images.d
+++ b/source/openai/images.d
@@ -1,0 +1,175 @@
+/**
+OpenAI API Images
+
+Standards: https://platform.openai.com/docs/api-reference/images
+*/
+module openai.images;
+
+import mir.serde;
+
+@safe:
+
+// -----------------------------------------------------------------------------
+// Enumerations
+// -----------------------------------------------------------------------------
+
+/// Square resolution 256x256.
+enum ImageSize256x256 = "256x256";
+/// Square resolution 512x512.
+enum ImageSize512x512 = "512x512";
+/// Square resolution 1024x1024.
+enum ImageSize1024x1024 = "1024x1024";
+/// Landscape resolution 1792x1024.
+enum ImageSize1792x1024 = "1792x1024";
+/// Portrait resolution 1024x1792.
+enum ImageSize1024x1792 = "1024x1792";
+/// Landscape resolution 1536x1024.
+enum ImageSize1536x1024 = "1536x1024";
+/// Portrait resolution 1024x1536.
+enum ImageSize1024x1536 = "1024x1536";
+
+/// Standard image quality.
+enum ImageQualityStandard = "standard";
+/// High definition image quality.
+enum ImageQualityHd = "hd";
+
+/// Vivid artistic style.
+enum ImageStyleVivid = "vivid";
+/// Natural artistic style.
+enum ImageStyleNatural = "natural";
+
+/// Return an URL to the generated image.
+enum ImageResponseFormatUrl = "url";
+/// Return base64 encoded image content.
+enum ImageResponseFormatB64Json = "b64_json";
+
+// -----------------------------------------------------------------------------
+// Requests
+// -----------------------------------------------------------------------------
+
+/// Request for `/images/generations`.
+struct ImageGenerationRequest
+{
+    string prompt;
+    @serdeIgnoreDefault
+    string model;
+    @serdeIgnoreDefault
+    uint n = 1;
+    @serdeIgnoreDefault
+    string quality;
+    @serdeIgnoreDefault
+    string style;
+    @serdeIgnoreDefault
+    string size;
+    @serdeIgnoreDefault
+    @serdeKeys("response_format")
+    string responseFormat = ImageResponseFormatUrl;
+    @serdeIgnoreDefault
+    string user;
+}
+
+/// Convenience constructor for image generation requests.
+ImageGenerationRequest imageGenerationRequest(string prompt)
+{
+    auto req = ImageGenerationRequest();
+    req.prompt = prompt;
+    return req;
+}
+
+/// Request for `/images/edits`.
+struct ImageEditRequest
+{
+    string image;
+    @serdeIgnoreDefault
+    string mask;
+    string prompt;
+    @serdeIgnoreDefault
+    string model;
+    @serdeIgnoreDefault
+    uint n = 1;
+    @serdeIgnoreDefault
+    string size;
+    @serdeIgnoreDefault
+    @serdeKeys("response_format")
+    string responseFormat = ImageResponseFormatUrl;
+    @serdeIgnoreDefault
+    string user;
+}
+
+/// Convenience constructor for image edit requests.
+ImageEditRequest imageEditRequest(string image, string prompt)
+{
+    auto req = ImageEditRequest();
+    req.image = image;
+    req.prompt = prompt;
+    return req;
+}
+
+/// Request for `/images/variations`.
+struct ImageVariationRequest
+{
+    string image;
+    @serdeIgnoreDefault
+    string model;
+    @serdeIgnoreDefault
+    uint n = 1;
+    @serdeIgnoreDefault
+    string size;
+    @serdeIgnoreDefault
+    @serdeKeys("response_format")
+    string responseFormat = ImageResponseFormatUrl;
+    @serdeIgnoreDefault
+    string user;
+}
+
+/// Convenience constructor for image variation requests.
+ImageVariationRequest imageVariationRequest(string image)
+{
+    auto req = ImageVariationRequest();
+    req.image = image;
+    return req;
+}
+
+// -----------------------------------------------------------------------------
+// Responses
+// -----------------------------------------------------------------------------
+
+struct GeneratedImage
+{
+    @serdeOptional
+    @serdeKeys("b64_json")
+    string b64Json;
+    @serdeOptional
+    string url;
+    @serdeOptional
+    @serdeKeys("revised_prompt")
+    string revisedPrompt;
+}
+
+struct ImageResponse
+{
+    long created;
+    GeneratedImage[] data;
+}
+
+// -----------------------------------------------------------------------------
+// Unit tests
+// -----------------------------------------------------------------------------
+
+unittest
+{
+    auto req = imageGenerationRequest("A cat");
+    import mir.ser.json : serializeJson;
+
+    assert(serializeJson(req) == `{"prompt":"A cat"}`);
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    const json = `{"created":1,"data":[{"b64_json":"aa"}]}`;
+    auto res = deserializeJson!ImageResponse(json);
+    assert(res.data.length == 1);
+    assert(res.data[0].b64Json == "aa");
+}

--- a/source/openai/package.d
+++ b/source/openai/package.d
@@ -13,4 +13,5 @@ public import openai.embedding;
 public import openai.models;
 public import openai.moderation;
 public import openai.audio;
+public import openai.images;
 public import openai.responses;


### PR DESCRIPTION
## Summary
- add `openai.images` module with enums, requests, and responses
- implement `imageGeneration`, `imageEdit`, and `imageVariation` client methods
- expose images module from package
- provide new images example and update README
- add unit tests and reflection log

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_684b6433053c832c9db613582a01a5a5