### PR TITLE
[github] add Codecov integration

### DIFF
--- a/.agents/reflections/2025-06-12-2305-add-codecov-integration.md
+++ b/.agents/reflections/2025-06-12-2305-add-codecov-integration.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-12 23:05]
+  - **Task**: Add Codecov integration
+  - **Objective**: Enable automated coverage reporting in CI
+  - **Outcome**: Added Codecov config, updated CI workflow to upload coverage, and updated README badge
+
+#### :sparkles: What went well
+  - Workflow changes applied smoothly and local tests passed
+
+#### :warning: Pain points
+  - Local: `dub lint` downloaded many dependencies, slowing the check
+
+#### :bulb: Proposed Improvement
+  - Provide a cached Docker image with common D tools preinstalled to speed up local linting
+<!-- reflection-template:end -->

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  require_ci_to_pass: yes
+coverage:
+  precision: 2
+  round: down
+comment: false

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -29,7 +29,11 @@ jobs:
       - name: Lint
         run: dub lint --dscanner-config dscanner.ini
       - name: Test
-        run: dub test --compiler=$DC
+        run: dub test --compiler=$DC --coverage --coverage-ctfe
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build examples
         run: |
           for dir in examples/*; do
@@ -60,7 +64,11 @@ jobs:
       - name: Lint
         run: dub lint --dscanner-config dscanner.ini
       - name: Test
-        run: dub test --compiler=$Env:DC
+        run: dub test --compiler=$Env:DC --coverage --coverage-ctfe
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build examples
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenAI API for D
 
 [![main CI](https://github.com/lempiji/openai-d/actions/workflows/main-ci.yaml/badge.svg)](https://github.com/lempiji/openai-d/actions/workflows/main-ci.yaml)
+[![codecov](https://codecov.io/gh/lempiji/openai-d/branch/main/graph/badge.svg)](https://codecov.io/gh/lempiji/openai-d)
 [![Latest Release](https://img.shields.io/github/v/release/lempiji/openai-d.svg)](https://github.com/lempiji/openai-d/releases)
 [![DUB](https://img.shields.io/dub/v/openai-d.svg)](https://code.dlang.org/packages/openai-d)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)


### PR DESCRIPTION
## Summary
- enable code coverage uploads via Codecov
- show Codecov badge in README
- document reflection on the process

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_684b5c6d1738832ca94a03b0f12698b0