### PR TITLE
[clients] encode list input items URL

### DIFF
--- a/.agents/reflections/2025-06-13-1428-encode-list-input-url.md
+++ b/.agents/reflections/2025-06-13-1428-encode-list-input-url.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-13 14:28]
+  - **Task**: Update buildListInputItemsUrl to encode query values and add tests
+  - **Objective**: Ensure query parameters are URL encoded when building list input items URLs
+  - **Outcome**: Function updated with std.uri.encodeComponent and new unittest verifies encoding; formatter, linter, tests and coverage all succeed
+
+#### :sparkles: What went well
+  - Code modifications were straightforward and unit tests provided quick verification
+
+#### :warning: Pain points
+  - Local, Ubuntu: `dub lint` fetched many dependencies and built tools which slowed the workflow
+
+#### :bulb: Proposed Improvement
+  - Cache prebuilt linter binaries to avoid repeated compilation during development
+<!-- reflection-template:end -->


### PR DESCRIPTION
## Summary
- URL encode query params in `buildListInputItemsUrl`
- test encoding of special characters
- add reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `./scripts/build_examples.sh fast`

------
https://chatgpt.com/codex/tasks/task_e_684c34bd805c832c965cd704a99b2031