### PR TITLE
[docs] clarify reflection archive process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,3 +105,4 @@ After completing your tasks, the agent **must create** a new file in `.agents/re
 * Records are keyed by timestamp (to the minute). Use the current date and time as `YYYY-MM-DD HH:MM` in the template and file name.
 * Replace `{task-summary}` with a short hyphenated summary of the task.
 * When documenting pain points, include your environment (CI, local machine, OS, etc.) and specify which step or command was slow.
+* After your proposed improvement is implemented, move the reflection to `.agents/archive/`. See [`.agents/reflections/AGENTS.md`](.agents/reflections/AGENTS.md) for the full archiving workflow.


### PR DESCRIPTION
## Summary
- document when to move reflections to `.agents/archive`
- point to `.agents/reflections/AGENTS.md` for full workflow

## Testing
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_684d43c85564832c96b003b22d6bc8f8