### PR TITLE
[responses] support discriminated output messages

### DIFF
--- a/.agents/reflections/2025-06-14-1827-allow-nullable-fields.md
+++ b/.agents/reflections/2025-06-14-1827-allow-nullable-fields.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-14 18:27]
+- **Task**: Adjust ResponsesResponse to handle null fields
+- **Objective**: Fix deserialization of API responses with null values
+- **Outcome**: Updated struct members to use Nullable and confirmed tests pass
+
+#### :sparkles: What went well
+- Compilation and unit tests ran quickly
+- The project tooling made it easy to format and lint changes
+
+#### :warning: Pain points
+- Understanding mir-serde's error messages was difficult when deserialization failed
+- Running `dub test` repeatedly slowed iteration during debugging
+
+#### :bulb: Proposed Improvement
+- Document common mir-serde errors in CONTRIBUTING to speed up future debugging

--- a/.agents/reflections/2025-06-15-0204-output-message-deserialization.md
+++ b/.agents/reflections/2025-06-15-0204-output-message-deserialization.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-15 02:04]
+  - **Task**: Fix OutputMessage deserialization
+  - **Objective**: Ensure Algebraic output types parse correctly
+  - **Outcome**: Added discriminated field annotations and tests
+
+#### :sparkles: What went well
+  - Unit tests quickly revealed issues with enum parsing
+  - dfmt and dscanner ran without problems
+
+#### :warning: Pain points
+  - Investigating mir-ion errors required trial and error
+  - Understanding enum handling in mir-serde was unclear
+
+#### :bulb: Proposed Improvement
+  - Document how mir-ion expects enums to be encoded to reduce debugging time


### PR DESCRIPTION
## Summary
- fix OutputMessage deserialization by tagging OutputTextContent and RefusalContent with `@serdeDiscriminatedField`
- parse TextResponseFormatConfiguration type as a plain string
- add unit tests for OutputMessage and ResponsesResponse
- document the update in a new reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_684dbc31c44c832cb29e06695ac940f7