### PR TITLE
[scripts] improve example build selection

### DIFF
--- a/.agents/reflections/2025-06-15-1154-update-example-build-script.md
+++ b/.agents/reflections/2025-06-15-1154-update-example-build-script.md
@@ -1,0 +1,15 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-15 11:54]
+  - **Task**: Extend build_examples.sh to support groups
+  - **Objective**: Allow faster builds of targeted example categories
+  - **Outcome**: Updated script parses group names, filters fast mode within them and updated documentation
+
+#### :sparkles: What went well
+  - Script logic remained simple while gaining flexibility
+
+#### :warning: Pain points
+  - Local Linux: building grouped examples still fetched dependencies for each run
+
+#### :bulb: Proposed Improvement
+  - Cache example builds or use incremental compilation to reduce repeated dependency fetches
+<!-- reflection-template:end -->


### PR DESCRIPTION
## Summary
- extend `build_examples.sh` to accept one or more group names
- filter fast mode within selected groups
- document new usage
- add reflection on the build script changes

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `./scripts/build_examples.sh fast chat`
- `./scripts/build_examples.sh all audio`


------
https://chatgpt.com/codex/tasks/task_e_684eb37e37a4832ca5932ce1361e3ffa