### PR TITLE
[docs] add CI investigation reflection

### DIFF
--- a/.agents/reflections/2025-06-15-1222-ci-investigation.md
+++ b/.agents/reflections/2025-06-15-1222-ci-investigation.md
@@ -1,0 +1,17 @@
+<!-- reflection-template:start -->
+### :book: Reflection for [2025-06-15 12:22]
+  - **Task**: Investigate CI failure
+  - **Objective**: Determine why the `main CI` workflow fails and implement a fix if possible
+  - **Outcome**: Local builds, lint, tests and examples succeeded for both DMD and LDC. Unable to reproduce CI failure without GitHub logs, so no fix applied.
+
+#### :sparkles: What went well
+  - The project setup script allowed running formatter, linter and tests easily.
+  - CI workflow file was simple to inspect.
+
+#### :warning: Pain points
+  - Lacked access to GitHub Actions logs, so the failing step could not be identified.
+  - Installing alternative D compilers via the provided script failed due to network restrictions.
+
+#### :bulb: Proposed Improvement
+  - Provide a downloadable archive of recent CI logs in the repository to aid offline debugging.
+<!-- reflection-template:end -->


### PR DESCRIPTION
## Summary
- document investigation into the failing main CI workflow

## Testing
- `dub run dfmt -- --version`
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test --compiler=ldc2`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684eb9bc74a0832cb1c52de9a4df2409