### PR TITLE
[examples] fix ChatCompletionTool usage

### DIFF
--- a/.agents/reflections/2025-06-15-1249-fix-chat-tools-init.md
+++ b/.agents/reflections/2025-06-15-1249-fix-chat-tools-init.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-15 12:49]
+- **Task**: Fix examples using ChatCompletionTool initialization
+- **Objective**: Correct initialization errors causing compile issues and update examples accordingly
+- **Outcome**: Updated chat_db and chat_tools examples to remove extra "function" argument; tests and linters pass
+
+#### :sparkles: What went well
+- Dfmt quickly formatted updated files
+- Test suite executed without failures after fix
+
+#### :warning: Pain points
+- Linter installation pulled many dependencies, slowing lint step
+- Manual environment setup for dmd required script invocation
+
+#### :bulb: Proposed Improvement
+- Provide a script or container with preinstalled D toolchain and dscanner to speed up setup

--- a/examples/chat_db/source/app.d
+++ b/examples/chat_db/source/app.d
@@ -40,7 +40,6 @@ void main()
     // dfmt off
     request.tools = [
         ChatCompletionTool(
-            "function",
             ChatCompletionFunction(
                 "execute_query",
                 "Executes a given SQL query using sqlite3. Supports various query types such as CREATE TABLE, SELECT, DELETE, etc. On successful execution of a SELECT query, it returns the fetched records.",

--- a/examples/chat_tools/source/app.d
+++ b/examples/chat_tools/source/app.d
@@ -16,7 +16,7 @@ void main()
     // define tools
     // dfmt off
     request.tools = [
-        ChatCompletionTool("function",
+        ChatCompletionTool(
             ChatCompletionFunction(
                 "add", "add 2 numbers",
                 JsonSchema.object_([
@@ -26,7 +26,7 @@ void main()
                 true
             )
         ),
-        ChatCompletionTool("function",
+        ChatCompletionTool(
             ChatCompletionFunction(
                 "sub", "subtract 2 numbers",
                 JsonSchema.object_([


### PR DESCRIPTION
## Summary
- fix ChatCompletionTool instantiation in chat_db and chat_tools examples
- add reflection note

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `dub lint --dscanner-config dscanner.ini`


------
https://chatgpt.com/codex/tasks/task_e_684ec0239be0832c9d34cd701fe49f8c