### PR TITLE
[docs] Add license section

### DIFF
--- a/.agents/reflections/2025-06-15-1416-add-license-section.md
+++ b/.agents/reflections/2025-06-15-1416-add-license-section.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-15 14:16]
+  - **Task**: Add license section to README
+  - **Objective**: Document license in README
+  - **Outcome**: Added `## License` section linking to MIT license file
+
+#### :sparkles: What went well
+  - Straightforward documentation update
+  - No build or tests required
+
+#### :warning: Pain points
+  - None
+
+#### :bulb: Proposed Improvement
+  - Automate insertion of common sections in docs

--- a/README.md
+++ b/README.md
@@ -279,3 +279,7 @@ import openai;
 auto config = new OpenAIClientConfig("<Your OpenAI API Key>");
 auto client = new OpenAIClient(config);
 ```
+
+## License
+
+This project is released under the [MIT license](LICENSE).


### PR DESCRIPTION
## Summary
- document MIT license in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ed56678c8832c9fad0703637cb728