### PR TITLE
[docs] fix administration bullet alignment

### DIFF
--- a/.agents/reflections/2025-06-15-1418-fix-administration-bullet.md
+++ b/.agents/reflections/2025-06-15-1418-fix-administration-bullet.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-15 14:18]
+  - **Task**: Align README bullet
+  - **Objective**: Correct indentation for the Administration checklist item
+  - **Outcome**: Bullet aligned with others and repository formatting remained stable
+
+#### :sparkles: What went well
+  - Simple documentation edit was straightforward
+  - Automated checks ran without issues
+
+#### :warning: Pain points
+  - Running formatter and linter for a doc-only change felt excessive
+  - Test suite adds time even when no code changed
+
+#### :bulb: Proposed Improvement
+  - Add a lightweight path for documentation-only PRs that skips building steps
+  - Cache dependencies locally to reduce test setup time

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
 - [ ] [Vector stores](https://platform.openai.com/docs/api-reference/vector-stores) (TODO)
 - [ ] [Containers](https://platform.openai.com/docs/api-reference/containers) (TODO)
 - [ ] [Assistants (Beta)](https://platform.openai.com/docs/api-reference/assistants) (TODO)
- - [x] [Administration](https://platform.openai.com/docs/api-reference/administration)
+- [x] [Administration](https://platform.openai.com/docs/api-reference/administration)
 
 __legacy__
 - [x] Completions (Legacy)


### PR DESCRIPTION
## Summary
- fix alignment of Administration bullet in README
- add reflection for the fix

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_684ed570c5f8832c9d6cf7b44bb8f66d