### PR TITLE
[build] format code and update dfmt guidelines

### DIFF
--- a/.agents/reflections/2025-06-15-1522-dfmt-formatting-update.md
+++ b/.agents/reflections/2025-06-15-1522-dfmt-formatting-update.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-15 15:22]
+  - **Task**: Run dfmt and update AGENTS instructions
+  - **Objective**: Ensure repository formatting is up to date and discourage manual tweaks
+  - **Outcome**: dfmt run successfully, AGENTS now strongly warns against editing formatting
+
+#### :sparkles: What went well
+  - dfmt ran without issues
+  - Tests passed on first try
+
+#### :warning: Pain points
+  - Running linter took some time to download dependencies
+
+#### :bulb: Proposed Improvement
+  - Cache dscanner and dfmt dependencies to speed up linting and formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
   dub fetch dfmt && dub run dfmt -- --version
   ```
   Network access or a setup script is required for this step.
+* **Run dfmt immediately before committing and never alter its output by hand.**
 
 * Library source:
 
@@ -56,6 +57,7 @@
   ```
 
 * CI runs dfmt on `source` and `examples` and fails if `git diff --exit-code` detects changes.
+* **Never edit dfmt output manually. Commit formatting changes exactly as produced.**
 
 ## 6. Linter
 

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -1000,7 +1000,9 @@ class OpenAIClient
     }
 
     private void appendFileChunked(scope ref Appender!(ubyte[])
+
         
+
         body,
         string boundary,
         string name,


### PR DESCRIPTION
## Summary
- run `dfmt` on sources
- document that dfmt output must never be changed manually
- add reflection for this task

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_684ee4980474832c9ac2d43b9eedd31e