### PR TITLE
[docs] remove redundant streaming note

### DIFF
--- a/.agents/reflections/2025-06-15-1531-chat-streaming-design.md
+++ b/.agents/reflections/2025-06-15-1531-chat-streaming-design.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-15 15:31]
+  - **Task**: Add chat streaming design document and README link
+  - **Objective**: Document planned streaming support and update README
+  - **Outcome**: Added new markdown file detailing requirements and proposed API, and linked it from README
+
+#### :sparkles: What went well
+  - Repository had clear guidelines for formatting and testing
+  - Tools like dfmt and dub worked without issues
+
+#### :warning: Pain points
+  - Docs directory was ignored in `.gitignore` so adding the file required forcing git add
+
+#### :bulb: Proposed Improvement
+  - Remove `docs/` from `.gitignore` to allow documentation changes without manual overrides

--- a/.agents/reflections/2025-06-15-1536-remove-redundant-note.md
+++ b/.agents/reflections/2025-06-15-1536-remove-redundant-note.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-15 15:36]
+  - **Task**: Address README comment
+  - **Objective**: Remove redundant streaming note from README as requested
+  - **Outcome**: Deleted the extra line and confirmed tests still pass
+
+#### :sparkles: What went well
+  - Clear diff comment made the change straightforward
+  - Automated format, lint, and tests ran quickly
+
+#### :warning: Pain points
+  - None for this small fix
+
+#### :bulb: Proposed Improvement
+  - A small lint script could check for stray README lines referencing features in development

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
 ![GitHub stars](https://img.shields.io/github/stars/lempiji/openai-d.svg)
 
-This library provides unofficial D clients for [OpenAI API](https://platform.openai.com)
+This library provides unofficial D clients for [OpenAI API](https://platform.openai.com).
 
 ## Requirements
 
@@ -30,7 +30,7 @@ or run `/workspace/dlang/install.sh` to set them up.
   - [x] tools (function_call)
   - [x] structured output
   - [x] input vision
-  - [ ] stream
+  - [ ] stream [(design)](docs/chat-streaming-design.md)
 - [ ] [Realtime (Beta)](https://platform.openai.com/docs/api-reference/realtime) (TODO)
 - [x] [Audio](https://platform.openai.com/docs/api-reference/audio)
   - [x] speech

--- a/docs/chat-streaming-design.md
+++ b/docs/chat-streaming-design.md
@@ -1,0 +1,45 @@
+# Chat Streaming Design
+
+This document outlines the initial design for enabling streaming responses from `/chat/completions`.
+
+## Requirements
+
+- Support server-sent events (SSE) so that chat completions can be received incrementally.
+- Ensure errors during a stream close the connection and surface an exception to the caller.
+- The existing `ChatCompletionRequest.stream` flag should enable or disable streaming.
+
+## Proposed Client API
+
+Two approaches are considered:
+
+1. **Iterator interface** – return a lazy range yielding `ChatCompletionChunk` objects.
+2. **Callback interface** – accept a delegate that is invoked with each chunk as it arrives.
+
+Both approaches must allow the caller to stop early and handle errors gracefully.
+
+## Usage Examples
+
+### Synchronous (current behaviour)
+
+```d
+auto request = chatCompletionRequest(model, messages);
+auto response = client.chatCompletion(request); // waits for full response
+```
+
+### Streaming
+
+```d
+auto request = chatCompletionRequest(model, messages);
+request.stream = true;
+
+// Iterator style
+foreach (chunk; client.chatCompletionStream(request)) {
+    writeln(chunk.choices[0].delta.content);
+}
+
+// Callback style
+client.chatCompletionStream(request, (chunk) {
+    writeln(chunk.choices[0].delta.content);
+});
+```
+


### PR DESCRIPTION
## Summary
- remove duplicate streaming note in the README
- record reflection about this fix

## Testing
- `dub run dfmt -- source && dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684ee657a054832c9aeac3dc9956e3d6