### PR TITLE
[responses] URL-encode include parameters

### DIFF
--- a/.agents/reflections/2025-06-15-1544-encode-include-values.md
+++ b/.agents/reflections/2025-06-15-1544-encode-include-values.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-15 15:44]
+  - **Task**: Encode include values in getResponse
+  - **Objective**: Ensure query parameters are correctly escaped
+  - **Outcome**: Updated implementation with URL encoding and added tests
+
+#### :sparkles: What went well
+  - Project guidelines made formatting and linting straightforward
+  - Example build script caught potential issues before commit
+
+#### :warning: Pain points
+  - Local, Ubuntu: creating a temporary dub project to inspect private functions was clumsy
+  - Rebuilding dependencies during example compilation added noticeable time
+
+#### :bulb: Proposed Improvement
+  - Provide a script or helper to quickly run small snippets against the library without crafting full dub projects

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -663,9 +663,7 @@ class OpenAIClient
         setupHttpByConfig(http);
         http.addRequestHeader("Accept", "application/json; charset=utf-8");
 
-        string url = buildUrl("/responses/" ~ responseId);
-        if (include !is null && include.length)
-            url ~= "?include=" ~ cast(string) include.joiner(",").array;
+        string url = buildGetResponseUrl(responseId, include);
 
         auto content = cast(char[]) get!(HTTP, ubyte)(url, http);
         auto result = content.deserializeJson!ResponsesResponse();
@@ -779,6 +777,7 @@ class OpenAIClient
     {
         import std.format : format;
         import std.algorithm : map;
+        import std.conv : to;
         import std.uri : encodeComponent;
 
         auto http = HTTP();
@@ -960,6 +959,23 @@ class OpenAIClient
                     .map!(x => encodeComponent(cast(string) x))
                     .joiner(",")
                     .array);
+        return url;
+    }
+
+    private string buildGetResponseUrl(string responseId, string[] include) const @safe
+    {
+        import std.algorithm : map;
+        import std.conv : to;
+        import std.uri : encodeComponent;
+
+        string url = buildUrl("/responses/" ~ responseId);
+        if (include !is null && include.length)
+            url ~= "?include="
+                ~ to!string(
+                    include
+                        .map!(x => encodeComponent(cast(string) x))
+                        .joiner(",")
+                        .array);
         return url;
     }
 
@@ -1385,4 +1401,18 @@ unittest
     assert(url.canFind("order=custom%20%40order"));
     assert(url.canFind("after=foo%20bar"));
     assert(url.canFind("before=bar%2Bbaz"));
+}
+
+@("getResponse encodes include values")
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    auto cfg = new OpenAIClientConfig;
+    cfg.apiKey = "k";
+    auto client = new OpenAIClient(cfg);
+
+    auto url = client.buildGetResponseUrl("resp", ["foo bar", "bar+baz"]);
+
+    assert(url.canFind("include=foo%20bar,bar%2Bbaz"));
 }


### PR DESCRIPTION
## Summary
- encode `include` items in `getResponse`
- add helper `buildGetResponseUrl`
- test encoding logic
- record reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684ee868f6f8832cbd1f20da6d5247fd