### PR TITLE
[docs] clean reflection template markers

### DIFF
--- a/.agents/archive/2025-06-11-0000-document-reflection-log-guidelines.md
+++ b/.agents/archive/2025-06-11-0000-document-reflection-log-guidelines.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-11 00:00
+### :book: Reflection for [2025-06-11 00:00]
   - **Task**: Document reflection log guidelines
   - **Objective**: Prevent duplicate dates and maintain chronological order
   - **Outcome**: Updated AGENTS.md with instructions to deduplicate and append history properly
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache linter dependencies to speed up future runs
-<!-- reflection-template:end -->

--- a/.agents/archive/2025-06-11-0000-document-request-helper-functions.md
+++ b/.agents/archive/2025-06-11-0000-document-request-helper-functions.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-11 00:00
+### :book: Reflection for [2025-06-11 00:00]
   - **Task**: Document request helper functions
   - **Objective**: Clarify usage of helper constructors for OpenAI API requests
   - **Outcome**: Added Ddoc comments summarizing parameters and target endpoints
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a helper script to build all example projects in one step
-<!-- reflection-template:end -->

--- a/.agents/archive/REFLECTION_HISTORY.md
+++ b/.agents/archive/REFLECTION_HISTORY.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [YYYY-MM-DD HH:MM]
   - **Task**: [Task Name or Description]
   - **Objective**: [What was the goal of the task?]
@@ -12,10 +11,9 @@
 
 #### :bulb: Proposed Improvement
   - …
-<!-- reflection-template:end -->
 
 ## :memo: Reflection History
-### :book: Reflection for 2025-06-10
+### :book: Reflection for [2025-06-10]
   - **Task**: Update chat helpers documentation
   - **Objective**: Expand comments for message constructors and document `chatCompletionRequest` parameters.
   - **Outcome**: Added detailed doc comments and verified formatting, linting, tests, coverage and example builds.
@@ -29,7 +27,7 @@
 #### :bulb: Proposed Improvement
   - Provide pre-built artifacts or a cached dependencies layer to speed up example builds.
 
-### :book: Reflection for 2025-06-10
+### :book: Reflection for [2025-06-10]
   - **Task**: Add doc comments for configuration and API methods
   - **Objective**: Improve library documentation clarity
   - **Outcome**: Added detailed descriptions to methods and ensured tests pass
@@ -43,7 +41,7 @@
 #### :bulb: Proposed Improvement
   - Provide pre-built artifacts or caching for example builds to speed up CI
 
-### :book: Reflection for 2025-06-11
+### :book: Reflection for [2025-06-11]
   - **Task**: Document request helper functions
   - **Objective**: Clarify usage of helper constructors for OpenAI API requests
   - **Outcome**: Added Ddoc comments summarizing parameters and target endpoints
@@ -57,7 +55,7 @@
 #### :bulb: Proposed Improvement
   - Provide a helper script to build all example projects in one step
 
-### :book: Reflection for 2025-06-11
+### :book: Reflection for [2025-06-11]
   - **Task**: Replace new `OpenAIClient` style
   - **Objective**: Match README style across examples
   - **Outcome**: Updated every example to use `new OpenAIClient()` and verified formatting, linting, tests, coverage, and builds.
@@ -71,7 +69,7 @@
 #### :bulb: Proposed Improvement
   - Add a script to build all examples in parallel.
 
-### :book: Reflection for 2025-06-11
+### :book: Reflection for [2025-06-11]
   - **Task**: Document reflection log guidelines
   - **Objective**: Prevent duplicate dates and maintain chronological order
   - **Outcome**: Updated AGENTS.md with instructions to deduplicate and append history properly
@@ -85,7 +83,7 @@
 #### :bulb: Proposed Improvement
   - Cache linter dependencies to speed up future runs
 
-### :book: Reflection for 2025-06-11
+### :book: Reflection for [2025-06-11]
   - **Task**: Add example build script
   - **Objective**: Speed up building numerous example projects
   - **Outcome**: Created `scripts/build_examples.sh` with fast and all modes and documented its usage in AGENTS.md. Verified formatting, linting, tests, coverage and builds.
@@ -99,7 +97,7 @@
 #### :bulb: Proposed Improvement
   - Investigate caching compiled dependencies or using `dub`'s built-in package cache to allow safe parallel builds.
 
-### :book: Reflection for 2025-06-11
+### :book: Reflection for [2025-06-11]
   - **Task**: Cache Dub packages in CI
   - **Objective**: Speed up continuous integration by avoiding repeated downloads
   - **Outcome**: Added actions/cache steps to store `~/.dub/packages` on Linux and Windows
@@ -113,7 +111,7 @@
 #### :bulb: Proposed Improvement
 - Document recommended cache paths for different operating systems
 
-### :book: Reflection for 2025-06-12
+### :book: Reflection for [2025-06-12]
 - **Task**: Make metadata optional in responses
 - **Objective**: Ensure API structs support optional metadata fields
 - **Outcome**: Added `@serdeOptional` attribute, updated formatting, linting, tests, coverage and example builds
@@ -127,7 +125,7 @@
 ### :bulb: Proposed Improvement
 - Provide a script to summarize coverage results and clean up old lst files
 
-### :book: Reflection for 2025-06-12
+### :book: Reflection for [2025-06-12]
 - **Task**: Update environment variable handling
 - **Objective**: Ensure OPENAI_API_BASE uses default URL when unset or empty
 - **Outcome**: Changed configuration to use `environment.get(envApiBaseName, "")` and kept default fallback. Verified formatting, linting, tests, coverage and example builds.
@@ -141,7 +139,7 @@
 #### :bulb: Proposed Improvement
 - Automate cleanup of coverage artifacts after tests
 
-### :book: Reflection for 2025-06-11 13:46
+### :book: Reflection for [2025-06-11 13:46]
   - **Task**: Add timestamp to reflection history template
   - **Objective**: Avoid merge conflicts when multiple reflections occur on the same day
   - **Outcome**: Updated AGENTS instructions and template to include date and time
@@ -154,7 +152,7 @@
 
 #### :bulb: Proposed Improvement
   - Provide a lightweight documentation-only workflow to skip heavy builds
-### :book: Reflection for 2025-06-11 14:52
+### :book: Reflection for [2025-06-11 14:52]
   - **Task**: Adjust reflection formatting
   - **Objective**: Address reviewer comments to indent bullet lists and remove unnecessary tags
   - **Outcome**: Updated template and latest entry with proper list levels and cleaned tags
@@ -168,7 +166,7 @@
 #### :bulb: Proposed Improvement
   - Introduce a docs-only workflow to speed up checks
 
-### :book: Reflection for 2025-06-12 10:54
+### :book: Reflection for [2025-06-12 10:54]
   - **Task**: Fix reflection header levels
   - **Objective**: Clarify formatting blocks per reviewer comment
   - **Outcome**: Updated template and history entries to use consistent section levels
@@ -181,7 +179,7 @@
 
 #### :bulb: Proposed Improvement
   - Add a linter rule to validate reflection headings automatically
-### :book: Reflection for 2025-06-12 12:16
+### :book: Reflection for [2025-06-12 12:16]
   - **Task**: Ensure example dub.sdl files end with newline
   - **Objective**: Maintain formatting consistency across examples
   - **Outcome**: Added trailing newlines, ran formatter, linter, tests, coverage and example builds

--- a/.agents/reflections/2025-06-10-0000-add-doc-comments-for-config-and-api-methods.md
+++ b/.agents/reflections/2025-06-10-0000-add-doc-comments-for-config-and-api-methods.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-10 00:00
+### :book: Reflection for [2025-06-10 00:00]
   - **Task**: Add doc comments for configuration and API methods
   - **Objective**: Improve library documentation clarity
   - **Outcome**: Added detailed descriptions to methods and ensured tests pass
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide pre-built artifacts or caching for example builds to speed up CI
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-10-0000-update-chat-helpers-documentation.md
+++ b/.agents/reflections/2025-06-10-0000-update-chat-helpers-documentation.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-10 00:00
+### :book: Reflection for [2025-06-10 00:00]
   - **Task**: Update chat helpers documentation
   - **Objective**: Expand comments for message constructors and document `chatCompletionRequest` parameters.
   - **Outcome**: Added detailed doc comments and verified formatting, linting, tests, coverage and example builds.
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide pre-built artifacts or a cached dependencies layer to speed up example builds.
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-11-0000-add-example-build-script.md
+++ b/.agents/reflections/2025-06-11-0000-add-example-build-script.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-11 00:00
+### :book: Reflection for [2025-06-11 00:00]
   - **Task**: Add example build script
   - **Objective**: Speed up building numerous example projects
   - **Outcome**: Created `scripts/build_examples.sh` with fast and all modes and documented its usage in AGENTS.md. Verified formatting, linting, tests, coverage and builds.
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Investigate caching compiled dependencies or using `dub`'s built-in package cache to allow safe parallel builds.
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-11-0000-cache-dub-packages-in-ci.md
+++ b/.agents/reflections/2025-06-11-0000-cache-dub-packages-in-ci.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-11 00:00
+### :book: Reflection for [2025-06-11 00:00]
   - **Task**: Cache Dub packages in CI
   - **Objective**: Speed up continuous integration by avoiding repeated downloads
   - **Outcome**: Added actions/cache steps to store `~/.dub/packages` on Linux and Windows
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Document recommended cache paths for different operating systems
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-11-0000-replace-new-openaiclient-style.md
+++ b/.agents/reflections/2025-06-11-0000-replace-new-openaiclient-style.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-11 00:00
+### :book: Reflection for [2025-06-11 00:00]
   - **Task**: Replace new `OpenAIClient` style
   - **Objective**: Match README style across examples
   - **Outcome**: Updated every example to use `new OpenAIClient()` and verified formatting, linting, tests, coverage, and builds.
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Add a script to build all examples in parallel.
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-11-1346-add-timestamp-to-reflection-history-template.md
+++ b/.agents/reflections/2025-06-11-1346-add-timestamp-to-reflection-history-template.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-11 13:46
+### :book: Reflection for [2025-06-11 13:46]
   - **Task**: Add timestamp to reflection history template
   - **Objective**: Avoid merge conflicts when multiple reflections occur on the same day
   - **Outcome**: Updated AGENTS instructions and template to include date and time
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a lightweight documentation-only workflow to skip heavy builds
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-11-1452-adjust-reflection-formatting.md
+++ b/.agents/reflections/2025-06-11-1452-adjust-reflection-formatting.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-11 14:52
+### :book: Reflection for [2025-06-11 14:52]
   - **Task**: Adjust reflection formatting
   - **Objective**: Address reviewer comments to indent bullet lists and remove unnecessary tags
   - **Outcome**: Updated template and latest entry with proper list levels and cleaned tags
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Introduce a docs-only workflow to speed up checks
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-0000-make-metadata-optional-in-responses.md
+++ b/.agents/reflections/2025-06-12-0000-make-metadata-optional-in-responses.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-12 00:00
+### :book: Reflection for [2025-06-12 00:00]
   - **Task**: Make metadata optional in responses
   - **Objective**: Ensure API structs support optional metadata fields
   - **Outcome**: Added `@serdeOptional` attribute, updated formatting, linting, tests, coverage and example builds
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a script to summarize coverage results and clean up old lst files
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-0000-update-environment-variable-handling.md
+++ b/.agents/reflections/2025-06-12-0000-update-environment-variable-handling.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-12 00:00
+### :book: Reflection for [2025-06-12 00:00]
   - **Task**: Update environment variable handling
   - **Objective**: Ensure OPENAI_API_BASE uses default URL when unset or empty
   - **Outcome**: Changed configuration to use `environment.get(envApiBaseName, "")` and kept default fallback. Verified formatting, linting, tests, coverage and example builds.
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Automate cleanup of coverage artifacts after tests
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-1054-fix-reflection-header-levels.md
+++ b/.agents/reflections/2025-06-12-1054-fix-reflection-header-levels.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-12 10:54
+### :book: Reflection for [2025-06-12 10:54]
   - **Task**: Fix reflection header levels
   - **Objective**: Clarify formatting blocks per reviewer comment
   - **Outcome**: Updated template and history entries to use consistent section levels
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Add a linter rule to validate reflection headings automatically
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-1216-ensure-example-dub-sdl-files-end-with-newline.md
+++ b/.agents/reflections/2025-06-12-1216-ensure-example-dub-sdl-files-end-with-newline.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-12 12:16
+### :book: Reflection for [2025-06-12 12:16]
   - **Task**: Ensure example dub.sdl files end with newline
   - **Objective**: Maintain formatting consistency across examples
   - **Outcome**: Added trailing newlines, ran formatter, linter, tests, coverage and example builds
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Add a clean step to the example build script to remove generated artifacts automatically
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-1300-migrate-reflection-history.md
+++ b/.agents/reflections/2025-06-12-1300-migrate-reflection-history.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-12 13:00
+### :book: Reflection for [2025-06-12 13:00]
   - **Task**: Migrate reflections to per-file format
   - **Objective**: Convert REFLECTION_HISTORY.md entries to individual files for better organization
   - **Outcome**: Created separate reflection files and removed the old history document
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a script to automate migrating or creating reflection entries
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-1334-fix-temp-unit-spelling.md
+++ b/.agents/reflections/2025-06-12-1334-fix-temp-unit-spelling.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 13:34]
   - **Task**: Correct temperature unit typos
   - **Objective**: Replace misspelled "celcius" and "farenheit" in JSON schema examples and run checks
@@ -13,4 +12,3 @@
 
 #### :bulb: Proposed Improvement
   - Add a script to set up and cache D dependencies between tasks to speed up lint and coverage runs
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-1336-stream-audio-chunks.md
+++ b/.agents/reflections/2025-06-12-1336-stream-audio-chunks.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 13:36]
   - **Task**: Stream file chunks in audio methods
   - **Objective**: Use File.byChunk so large audio files don't load fully in memory
@@ -12,5 +11,4 @@
 
 #### :bulb: Proposed Improvement
   - Automate dependency caching in CI to speed up lint/test steps
-<!-- reflection-template:end -->
 

--- a/.agents/reflections/2025-06-12-1349-refactor-chunk-method-for-testability.md
+++ b/.agents/reflections/2025-06-12-1349-refactor-chunk-method-for-testability.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 13:49]
   - **Task**: Refactor streaming audio methods for testability
   - **Objective**: Extract chunked file logic into a private method and add unit tests
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Introduce helpers for creating temporary test resources
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2044-clarify-chunked-test.md
+++ b/.agents/reflections/2025-06-12-2044-clarify-chunked-test.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 20:44]
   - **Task**: Clarify chunked upload unit test
   - **Objective**: Remove dynamic filename from expected string and use explicit value
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache formatted binaries to avoid repeated compilation in CI
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2056-comment-chat-store-member.md
+++ b/.agents/reflections/2025-06-12-2056-comment-chat-store-member.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 20:56]
   - **Task**: Comment out store member in chat.d and adjust docs/tests
   - **Objective**: Remove usage of store parameter per OpenAI data policy
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide cached binaries for dfmt/dscanner to speed up CI and local runs
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2105-remove-chat-store-doc-comment.md
+++ b/.agents/reflections/2025-06-12-2105-remove-chat-store-doc-comment.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 21:05]
   - **Task**: Remove stray doc comment when commenting out store
   - **Objective**: Ensure no misleading documentation remains for the disabled store parameter
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache compiled versions of dfmt and dscanner tools to speed up workflows
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2107-remove-unused-import.md
+++ b/.agents/reflections/2025-06-12-2107-remove-unused-import.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 21:07]
   - **Task**: Clean up unused import in setupHttpByConfig
   - **Objective**: Remove the unnecessary `canFind` import and ensure compilation passes
@@ -12,5 +11,4 @@
 
 #### :bulb: Proposed Improvement
   - Implement a pre-commit script that scans for compilation errors before running full test suite to catch mistakes earlier
-<!-- reflection-template:end -->
 

--- a/.agents/reflections/2025-06-12-2119-cast-include-values.md
+++ b/.agents/reflections/2025-06-12-2119-cast-include-values.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 21:19]
   - **Task**: Replace to!string with cast(string) in listInputItems
   - **Objective**: Ensure include values are cast directly without to!string
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Add a clean step in build scripts to remove generated binaries automatically
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2134-deduplicate-file-import.md
+++ b/.agents/reflections/2025-06-12-2134-deduplicate-file-import.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 21:34]
   - **Task**: Address review comment
   - **Objective**: Remove duplicate File imports across audio methods
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache dfmt binaries between runs to speed up formatting
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2254-strip-trailing-newline.md
+++ b/.agents/reflections/2025-06-12-2254-strip-trailing-newline.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 22:54]
   - **Task**: Remove trailing newline in chat message text
   - **Objective**: Ensure `getAllTextContent` returns text without a newline suffix
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Add a make target to clean example build artifacts automatically
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2255-handle-empty-pagination.md
+++ b/.agents/reflections/2025-06-12-2255-handle-empty-pagination.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 22:55]
   - **Task**: Update pagination params and tests
   - **Objective**: Ensure query parameters are omitted when empty and maintain coverage
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache Dub dependencies to speed up example builds
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2305-add-codecov-integration.md
+++ b/.agents/reflections/2025-06-12-2305-add-codecov-integration.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 23:05]
   - **Task**: Add Codecov integration
   - **Objective**: Enable automated coverage reporting in CI
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a cached Docker image with common D tools preinstalled to speed up local linting
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-12-2345-images-api.md
+++ b/.agents/reflections/2025-06-12-2345-images-api.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-12 23:45]
   - **Task**: Implement Images API
   - **Objective**: Add image generation support with enums, client methods, examples and docs
@@ -13,4 +12,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache dscanner in CI to speed up lint executions
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-13-1428-encode-list-input-url.md
+++ b/.agents/reflections/2025-06-13-1428-encode-list-input-url.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-13 14:28]
   - **Task**: Update buildListInputItemsUrl to encode query values and add tests
   - **Objective**: Ensure query parameters are URL encoded when building list input items URLs
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache prebuilt linter binaries to avoid repeated compilation during development
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-13-1436-add-reflection-archiving-workflow.md
+++ b/.agents/reflections/2025-06-13-1436-add-reflection-archiving-workflow.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-13 14:36
+### :book: Reflection for [2025-06-13 14:36]
   - **Task**: Document reflection archiving workflow
   - **Objective**: Provide clear instructions for moving reflections once improvements are implemented
   - **Outcome**: Added AGENTS.md in `.agents/reflections` explaining the steps
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Create a helper script that lists reflections with unimplemented improvements
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-13-1436-archive-linter-cache-reflection.md
+++ b/.agents/reflections/2025-06-13-1436-archive-linter-cache-reflection.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-13 14:36]
   - **Task**: Archive reflection on linter cache
   - **Objective**: Move outdated reflection log to archive
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Automate reflection archival to avoid manual git operations
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-13-1438-archive-reflection-for-build-script.md
+++ b/.agents/reflections/2025-06-13-1438-archive-reflection-for-build-script.md
@@ -1,5 +1,4 @@
-<!-- reflection-template:start -->
-### :book: Reflection for 2025-06-13 14:38
+### :book: Reflection for [2025-06-13 14:38]
   - **Task**: Archive reflection for build script
   - **Objective**: Move an outdated reflection file to the archive folder
   - **Outcome**: Successfully moved the reflection and committed the change
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Update the build script or `.gitignore` to automatically exclude generated binaries to avoid manual cleanup
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-13-1533-administration-api.md
+++ b/.agents/reflections/2025-06-13-1533-administration-api.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-13 15:33]
   - **Task**: Implement Administration API support
   - **Objective**: Add administration data structures and client
@@ -13,4 +12,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache dub dependencies between runs to speed up lint and test steps
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-13-2207-add-admin-helpers.md
+++ b/.agents/reflections/2025-06-13-2207-add-admin-helpers.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-13 22:07]
   - **Task**: Add helper builders for administration requests
   - **Objective**: Provide convenience functions for constructing Administration API request structs
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache example build artifacts or dependencies to avoid repeated downloads during local builds
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-15-1154-update-example-build-script.md
+++ b/.agents/reflections/2025-06-15-1154-update-example-build-script.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-15 11:54]
   - **Task**: Extend build_examples.sh to support groups
   - **Objective**: Allow faster builds of targeted example categories
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache example builds or use incremental compilation to reduce repeated dependency fetches
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-15-1206-update-workflow-docs.md
+++ b/.agents/reflections/2025-06-15-1206-update-workflow-docs.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-15 12:06]
   - **Task**: Expand workflow docs for example build groups
   - **Objective**: Document new usage patterns for scripts/build_examples.sh
@@ -12,4 +11,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache dfmt and dscanner binaries in CI to avoid repeated installations
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-15-1222-ci-investigation.md
+++ b/.agents/reflections/2025-06-15-1222-ci-investigation.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-15 12:22]
   - **Task**: Investigate CI failure
   - **Objective**: Determine why the `main CI` workflow fails and implement a fix if possible
@@ -14,4 +13,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a downloadable archive of recent CI logs in the repository to aid offline debugging.
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-15-1454-ci-formatting-check.md
+++ b/.agents/reflections/2025-06-15-1454-ci-formatting-check.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-15 14:54]
   - **Task**: Add dfmt check to CI workflow
   - **Objective**: Ensure CI fails when code is not formatted
@@ -14,4 +13,3 @@
 
 #### :bulb: Proposed Improvement
   - Cache dfmt build artifacts in CI to speed up formatting checks
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-15-1502-fix-ci-step-order.md
+++ b/.agents/reflections/2025-06-15-1502-fix-ci-step-order.md
@@ -1,4 +1,3 @@
-<!-- reflection-template:start -->
 ### :book: Reflection for [2025-06-15 15:02]
   - **Task**: Adjust dfmt step ordering in CI
   - **Objective**: Ensure dfmt runs after dependencies are installed
@@ -13,4 +12,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a preconfigured docker image with dfmt installed to avoid rebuilds each CI run
-<!-- reflection-template:end -->

--- a/.agents/reflections/2025-06-15-1605-strip-template-comments.md
+++ b/.agents/reflections/2025-06-15-1605-strip-template-comments.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-15 16:05]
+  - **Task**: Remove template comments from reflections
+  - **Objective**: Clean up markdown files and standardize headers
+  - **Outcome**: Deleted comment markers and normalized timestamps across reflections
+
+#### :sparkles: What went well
+  - Sed automation handled all files consistently
+  - Tests and coverage passed without issues
+
+#### :warning: Pain points
+  - Local, Ubuntu: `dub lint` downloads dependencies every run, slowing feedback
+  - Building dfmt and dscanner adds overhead for docs-only changes
+
+#### :bulb: Proposed Improvement
+  - Cache linter and formatter binaries in CI to avoid repeated compilation
+  - Provide a lightweight docs workflow skipping example builds


### PR DESCRIPTION
## Summary
- remove `reflection-template` comment markers from all archived and active reflections
- normalize reflection headers with bracketed timestamps
- record today's cleanup in new reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_684eedb7f788832c838239078f76f70f