### PR TITLE
[openai] prevent dfmt formatting issue

### DIFF
--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -990,7 +990,9 @@ class OpenAIClient
             }
 
         body.put(cast(ubyte[])("--" ~ boundary ~ "--\r\n"));
+        // dfmt off
         return body.data;
+        // dfmt on
     }
 
     @("buildUrl - openai mode")


### PR DESCRIPTION
## Summary
- wrap return statement in `buildMultipartBody` with dfmt off/on comments

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684ef88535ac832cb6ba165f2f76e839