### PR TITLE
[docs] track docs folder

### DIFF
--- a/.agents/reflections/2025-06-15-2240-docs-gitignore-update.md
+++ b/.agents/reflections/2025-06-15-2240-docs-gitignore-update.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-15 22:40]
+  - **Task**: Update .gitignore to track docs folder
+  - **Objective**: Keep docs under version control while ignoring temporary files
+  - **Outcome**: Adjusted ignore rules and verified project checks
+
+#### :sparkles: What went well
+  - Formatting, linting, and tests ran without issues
+  - Removing the `docs/` entry was straightforward
+
+#### :warning: Pain points
+  - Running the full test suite took a couple minutes in the container
+
+#### :bulb: Proposed Improvement
+  - Provide a cached build of dependencies to speed up `dub test`

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .dub
 docs.json
 __dummy.html
-docs/
+docs/*.tmp
 /taskchain
 taskchain.so
 taskchain.dylib


### PR DESCRIPTION
## Summary
- track the docs directory by deleting the `docs/` ignore rule
- ignore `docs/*.tmp`
- add a reflection about updating `.gitignore`

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_684f4b10025c832c96fb1f35967c9468