### PR TITLE
[openai] enforce API key validation

### DIFF
--- a/.agents/reflections/2025-06-16-0043-enforce-api-key.md
+++ b/.agents/reflections/2025-06-16-0043-enforce-api-key.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-16 00:43]
+  - **Task**: enforce API key requirement
+  - **Objective**: add config validation and test
+  - **Outcome**: api key presence enforced with unit test
+
+#### :sparkles: What went well
+  - dfmt and lint ran smoothly
+  - tests and examples built without issues
+
+#### :warning: Pain points
+  - building examples produces many deprecation warnings slowing logs
+  - coverage files need manual inspection each time
+
+#### :bulb: Proposed Improvement
+  - add script to summarize coverage and filter warnings for quicker review

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -221,6 +221,9 @@ class OpenAIClient
     {
         import std.exception : enforce;
 
+        enforce(config.apiKey.length > 0,
+            "OPENAI_API_KEY is required");
+
         if (config.isAzure)
         {
             enforce(config.deploymentId.length > 0,
@@ -1238,6 +1241,14 @@ unittest
         environment.remove(ENV_OPENAI_DEPLOYMENT_ID);
 
     assertThrown!Exception(new OpenAIClient());
+}
+
+@("missing API key throws")
+unittest
+{
+    import std.exception : assertThrown;
+
+    assertThrown!Exception(new OpenAIClient(new OpenAIClientConfig()));
 }
 
 @("save & load config file - openai mode")


### PR DESCRIPTION
## Summary
- validate that OPENAI_API_KEY is provided
- test exception thrown when API key missing
- add reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_684f67a4eeec832c82a53ba4da6f824a