### PR TITLE
[administration] static nested audit structs

### DIFF
--- a/.agents/reflections/2025-06-16-1327-expand-audit-log-models.md
+++ b/.agents/reflections/2025-06-16-1327-expand-audit-log-models.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-16 13:27]
+- **Task**: Expand audit log models
+- **Objective**: Implement additional audit log structures and update tests.
+- **Outcome**: Added new structs, enum, and tests; all checks pass.
+
+#### :sparkles: What went well
+- Mir.serde handled the new structs smoothly.
+- Example build script confirmed compilation of examples.
+
+#### :warning: Pain points
+- Coverage and example builds produced noisy warnings which slowed down verification.
+
+#### :bulb: Proposed Improvement
+- Provide a make target that suppresses repeated deprecation warnings to streamline build output.

--- a/.agents/reflections/2025-06-16-1343-typed-audit-log-payloads.md
+++ b/.agents/reflections/2025-06-16-1343-typed-audit-log-payloads.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-16 13:43]
+- **Task**: Convert audit log payloads to typed structs
+- **Objective**: Replace JsonValue fields with explicit types and adjust tests
+- **Outcome**: Updated models and test pass after adding many struct definitions
+
+#### :sparkles: What went well
+- Mir.serde allowed nested structs to deserialize seamlessly
+- Linter and formatter required minimal adjustments
+
+#### :warning: Pain points
+- Following the OpenAPI spec manually was tedious and error-prone
+- Example builds still produce deprecation warnings cluttering logs
+
+#### :bulb: Proposed Improvement
+- Automate struct generation from the spec to avoid manual translation

--- a/.agents/reflections/2025-06-16-1356-audit-log-static-nested-structs.md
+++ b/.agents/reflections/2025-06-16-1356-audit-log-static-nested-structs.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-16 13:56]
+  - **Task**: Add static qualifiers to nested audit log payload structs
+  - **Objective**: Address inline comments requiring static nested structs
+  - **Outcome**: Added static qualifiers and verified with tests
+
+#### :sparkles: What went well
+  - Re-ran formatter and tests quickly
+  - Command chain stable with no errors
+
+#### :warning: Pain points
+  - Downloads during lint slow initial run
+  - Extra warnings clutter output
+
+#### :bulb: Proposed Improvement
+  - Cache tooling to speed up lint
+  - Silence deprecation messages

--- a/.agents/reflections/2025-06-16-2217-extract-audit-certificate.md
+++ b/.agents/reflections/2025-06-16-2217-extract-audit-certificate.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-16 22:17]
+  - **Task**: Extract audit certificate struct
+  - **Objective**: Remove duplicated nested structs in audit log events
+  - **Outcome**: Added `AuditLogEventCertificate` and updated activation/deactivation events
+
+#### :sparkles: What went well
+  - Fixing the duplication only touched a small code section
+  - Formatter and tests ran quickly with cached dependencies
+
+#### :warning: Pain points
+  - Example builds still print many deprecation warnings
+  - Linter fetch step slows down first runs
+
+#### :bulb: Proposed Improvement
+  - Cache dscanner and example dependencies in CI to cut setup time
+  - Investigate suppressing or fixing mir-core deprecation warnings

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -493,27 +493,22 @@ struct AuditLogCertificateDeleted
 }
 
 @serdeIgnoreUnexpectedKeys
+struct AuditLogEventCertificate
+{
+    string id;
+    string name;
+}
+
+@serdeIgnoreUnexpectedKeys
 struct AuditLogCertificatesActivated
 {
-    @serdeIgnoreUnexpectedKeys static struct Certificate
-    {
-        string id;
-        string name;
-    }
-
-    Certificate[] certificates;
+    AuditLogEventCertificate[] certificates;
 }
 
 @serdeIgnoreUnexpectedKeys
 struct AuditLogCertificatesDeactivated
 {
-    @serdeIgnoreUnexpectedKeys static struct Certificate
-    {
-        string id;
-        string name;
-    }
-
-    Certificate[] certificates;
+    AuditLogEventCertificate[] certificates;
 }
 
 @serdeIgnoreUnexpectedKeys

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -201,11 +201,394 @@ struct DeleteCertificateResponse
 }
 
 @serdeIgnoreUnexpectedKeys
+struct AuditLogProject
+{
+    string id;
+    string name;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogActorUser
+{
+    string id;
+    string email;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogActorServiceAccount
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogActorSession
+{
+    AuditLogActorUser user;
+    @serdeKeys("ip_address") string ipAddress;
+    @serdeOptional @serdeKeys("user_agent") string userAgent;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogActorApiKey
+{
+    string id;
+    string type;
+    @serdeOptional AuditLogActorUser user;
+    @serdeOptional @serdeKeys("service_account") AuditLogActorServiceAccount serviceAccount;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogApiKeyCreated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct Data
+    {
+        string[] scopes;
+    }
+
+    Data data;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogApiKeyUpdated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct ChangesRequested
+    {
+        string[] scopes;
+    }
+
+    @serdeKeys("changes_requested") ChangesRequested changesRequested;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogApiKeyDeleted
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogCheckpointPermissionCreated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct Data
+    {
+        @serdeKeys("project_id") string projectId;
+        @serdeKeys("fine_tuned_model_checkpoint") string fineTunedModelCheckpoint;
+    }
+
+    Data data;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogCheckpointPermissionDeleted
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogInviteSent
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct Data
+    {
+        string email;
+        string role;
+    }
+
+    Data data;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogInviteAccepted
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogInviteDeleted
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogLoginSucceeded
+{
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogLoginFailed
+{
+    @serdeKeys("error_code") string errorCode;
+    @serdeKeys("error_message") string errorMessage;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogLogoutSucceeded
+{
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogLogoutFailed
+{
+    @serdeKeys("error_code") string errorCode;
+    @serdeKeys("error_message") string errorMessage;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogOrganizationUpdated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct ChangesRequested
+    {
+        string title;
+        string description;
+        string name;
+        @serdeIgnoreUnexpectedKeys static struct Settings
+        {
+            @serdeKeys("threads_ui_visibility") string threadsUiVisibility;
+            @serdeKeys("usage_dashboard_visibility") string usageDashboardVisibility;
+        }
+
+        @serdeOptional Settings settings;
+    }
+
+    @serdeKeys("changes_requested") ChangesRequested changesRequested;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogProjectCreated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct Data
+    {
+        string name;
+        string title;
+    }
+
+    Data data;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogProjectUpdated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct ChangesRequested
+    {
+        string title;
+    }
+
+    @serdeKeys("changes_requested") ChangesRequested changesRequested;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogProjectArchived
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogServiceAccountCreated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct Data
+    {
+        string role;
+    }
+
+    Data data;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogServiceAccountUpdated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct ChangesRequested
+    {
+        string role;
+    }
+
+    @serdeKeys("changes_requested") ChangesRequested changesRequested;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogServiceAccountDeleted
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogRateLimitUpdated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct ChangesRequested
+    {
+        @serdeKeys("max_requests_per_1_minute") long maxRequestsPer1Minute;
+        @serdeKeys("max_tokens_per_1_minute") long maxTokensPer1Minute;
+        @serdeKeys("max_images_per_1_minute") long maxImagesPer1Minute;
+        @serdeKeys("max_audio_megabytes_per_1_minute") long maxAudioMegabytesPer1Minute;
+        @serdeKeys("max_requests_per_1_day") long maxRequestsPer1Day;
+        @serdeKeys("batch_1_day_max_input_tokens") long batch1DayMaxInputTokens;
+    }
+
+    @serdeKeys("changes_requested") ChangesRequested changesRequested;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogRateLimitDeleted
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogUserAdded
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct Data
+    {
+        string role;
+    }
+
+    Data data;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogUserUpdated
+{
+    string id;
+    @serdeIgnoreUnexpectedKeys static struct ChangesRequested
+    {
+        string role;
+    }
+
+    @serdeKeys("changes_requested") ChangesRequested changesRequested;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogUserDeleted
+{
+    string id;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogCertificateCreated
+{
+    string id;
+    string name;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogCertificateUpdated
+{
+    string id;
+    string name;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogCertificateDeleted
+{
+    string id;
+    string name;
+    string certificate;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogCertificatesActivated
+{
+    @serdeIgnoreUnexpectedKeys static struct Certificate
+    {
+        string id;
+        string name;
+    }
+
+    Certificate[] certificates;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogCertificatesDeactivated
+{
+    @serdeIgnoreUnexpectedKeys static struct Certificate
+    {
+        string id;
+        string name;
+    }
+
+    Certificate[] certificates;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct AuditLogActor
+{
+    string type;
+    @serdeOptional AuditLogActorSession session;
+    @serdeOptional @serdeKeys("api_key") AuditLogActorApiKey apiKey;
+}
+
+enum AuditLogEventType
+{
+    ApiKeyCreated = "api_key.created",
+    ApiKeyUpdated = "api_key.updated",
+    ApiKeyDeleted = "api_key.deleted",
+    CheckpointPermissionCreated = "checkpoint_permission.created",
+    CheckpointPermissionDeleted = "checkpoint_permission.deleted",
+    InviteSent = "invite.sent",
+    InviteAccepted = "invite.accepted",
+    InviteDeleted = "invite.deleted",
+    LoginSucceeded = "login.succeeded",
+    LoginFailed = "login.failed",
+    LogoutSucceeded = "logout.succeeded",
+    LogoutFailed = "logout.failed",
+    OrganizationUpdated = "organization.updated",
+    ProjectCreated = "project.created",
+    ProjectUpdated = "project.updated",
+    ProjectArchived = "project.archived",
+    ServiceAccountCreated = "service_account.created",
+    ServiceAccountUpdated = "service_account.updated",
+    ServiceAccountDeleted = "service_account.deleted",
+    RateLimitUpdated = "rate_limit.updated",
+    RateLimitDeleted = "rate_limit.deleted",
+    UserAdded = "user.added",
+    UserUpdated = "user.updated",
+    UserDeleted = "user.deleted",
+}
+
+@serdeIgnoreUnexpectedKeys
 struct AuditLog
 {
     string id;
     string type;
     @serdeKeys("effective_at") long effectiveAt;
+    @serdeOptional AuditLogProject project;
+    AuditLogActor actor;
+    @serdeOptional @serdeKeys("api_key.created") AuditLogApiKeyCreated apiKeyCreated;
+    @serdeOptional @serdeKeys("api_key.updated") AuditLogApiKeyUpdated apiKeyUpdated;
+    @serdeOptional @serdeKeys("api_key.deleted") AuditLogApiKeyDeleted apiKeyDeleted;
+    @serdeOptional @serdeKeys("checkpoint_permission.created") AuditLogCheckpointPermissionCreated checkpointPermissionCreated;
+    @serdeOptional @serdeKeys("checkpoint_permission.deleted") AuditLogCheckpointPermissionDeleted checkpointPermissionDeleted;
+    @serdeOptional @serdeKeys("invite.sent") AuditLogInviteSent inviteSent;
+    @serdeOptional @serdeKeys("invite.accepted") AuditLogInviteAccepted inviteAccepted;
+    @serdeOptional @serdeKeys("invite.deleted") AuditLogInviteDeleted inviteDeleted;
+    @serdeOptional @serdeKeys("login.succeeded") AuditLogLoginSucceeded loginSucceeded;
+    @serdeOptional @serdeKeys("login.failed") AuditLogLoginFailed loginFailed;
+    @serdeOptional @serdeKeys("logout.succeeded") AuditLogLogoutSucceeded logoutSucceeded;
+    @serdeOptional @serdeKeys("logout.failed") AuditLogLogoutFailed logoutFailed;
+    @serdeOptional @serdeKeys("organization.updated") AuditLogOrganizationUpdated organizationUpdated;
+    @serdeOptional @serdeKeys("project.created") AuditLogProjectCreated projectCreated;
+    @serdeOptional @serdeKeys("project.updated") AuditLogProjectUpdated projectUpdated;
+    @serdeOptional @serdeKeys("project.archived") AuditLogProjectArchived projectArchived;
+    @serdeOptional @serdeKeys("service_account.created") AuditLogServiceAccountCreated serviceAccountCreated;
+    @serdeOptional @serdeKeys("service_account.updated") AuditLogServiceAccountUpdated serviceAccountUpdated;
+    @serdeOptional @serdeKeys("service_account.deleted") AuditLogServiceAccountDeleted serviceAccountDeleted;
+    @serdeOptional @serdeKeys("rate_limit.updated") AuditLogRateLimitUpdated rateLimitUpdated;
+    @serdeOptional @serdeKeys("rate_limit.deleted") AuditLogRateLimitDeleted rateLimitDeleted;
+    @serdeOptional @serdeKeys("user.added") AuditLogUserAdded userAdded;
+    @serdeOptional @serdeKeys("user.updated") AuditLogUserUpdated userUpdated;
+    @serdeOptional @serdeKeys("user.deleted") AuditLogUserDeleted userDeleted;
+    @serdeOptional @serdeKeys("certificate.created") AuditLogCertificateCreated certificateCreated;
+    @serdeOptional @serdeKeys("certificate.updated") AuditLogCertificateUpdated certificateUpdated;
+    @serdeOptional @serdeKeys("certificate.deleted") AuditLogCertificateDeleted certificateDeleted;
+    @serdeOptional @serdeKeys("certificates.activated") AuditLogCertificatesActivated certificatesActivated;
+    @serdeOptional @serdeKeys("certificates.deactivated") AuditLogCertificatesDeactivated certificatesDeactivated;
 }
 
 @serdeIgnoreUnexpectedKeys
@@ -273,4 +656,19 @@ unittest
 
     auto req = listProjectsRequest(10, true);
     assert(serializeJson(req) == `{"limit":10,"include_archived":true}`);
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+    import mir.algebraic_alias.json : JsonAlgebraic;
+
+    enum example = `{"id":"req_xxx_20240101","type":"api_key.created","effective_at":1720804090,"actor":{"type":"session","session":{"user":{"id":"user-xxx","email":"user@example.com"},"ip_address":"127.0.0.1","user_agent":"Mozilla/5.0"}},"api_key.created":{"id":"key_xxxx","data":{"scopes":["resource.operation"]}}}`;
+    auto log = deserializeJson!AuditLog(example);
+    assert(log.id == "req_xxx_20240101");
+    assert(log.type == AuditLogEventType.ApiKeyCreated);
+    assert(log.actor.type == "session");
+    assert(log.actor.session.ipAddress == "127.0.0.1");
+    assert(log.apiKeyCreated.id == "key_xxxx");
+    assert(log.apiKeyCreated.data.scopes[0] == "resource.operation");
 }


### PR DESCRIPTION
## Summary
- mark nested structs within audit log payloads as `static`
- document the fix in a new reflection entry

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh fast`


------
https://chatgpt.com/codex/tasks/task_e_685019de52a4832c95a1691ad3606a42