### PR TITLE
[scripts] add core example build mode

### DIFF
--- a/.agents/reflections/2025-06-16-2258-core-example-build-update.md
+++ b/.agents/reflections/2025-06-16-2258-core-example-build-update.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-16 22:58]
+  - **Task**: Update example build script and docs
+  - **Objective**: Replace fast mode with core mode and ensure tooling still passes
+  - **Outcome**: Adjusted build script and docs, linter/tests pass though dfmt cannot format non-D files
+
+#### :sparkles: What went well
+  - Simple sed patches updated script and documentation quickly
+  - Automated tests ran successfully confirming functionality
+
+#### :warning: Pain points
+  - dfmt failed on bash and Markdown files producing long error logs
+  - Waiting for dependencies during linter execution slowed feedback
+
+#### :bulb: Proposed Improvement
+  - Add a shell and Markdown formatter to handle non-D files so dfmt step can be skipped when irrelevant

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,10 @@
 2. Run formatter and linter
 3. Run tests and coverage
 4. Build examples individually or use the helper script:
-   * Run `scripts/build_examples.sh fast` to compile only a small set of key examples.
+   * Run `scripts/build_examples.sh core` to compile only examples without underscores.
    * Run `scripts/build_examples.sh` (or `scripts/build_examples.sh all`) to build them all.
    * Run `scripts/build_examples.sh chat` to build every example starting with `chat`.
-   * Run `scripts/build_examples.sh fast audio` for a faster build of the `audio` group.
+   * Run `scripts/build_examples.sh core audio` for a faster build of the `audio` group.
    Building individually with `dub build` remains valid when touching only a few examples.
    * Build examples that have been modified,
      depend on changed library modules, or
@@ -86,7 +86,7 @@
    **Quick guide**
    - Use a single group such as `chat` when only that example directory changed.
    - Provide multiple groups (`chat audio`) if several examples were modified.
-   - Prefix with `fast` (`fast` or `fast <group>`) for quick iteration.
+   - Prefix with `core` (`core` or `core <group>`) for quicker iteration.
    - Use `all` to replicate CI builds or before a release.
 5. If all checks pass, commit changes and open a pull request.
 

--- a/scripts/build_examples.sh
+++ b/scripts/build_examples.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Build OpenAI D examples
-# Usage: build_examples.sh [all|fast] [GROUP ...]
+# Usage: build_examples.sh [all|core] [GROUP ...]
 #   all    - build every example project (default)
-#   fast   - build a subset of key examples to save time
+#   core   - build a subset of key examples without underscores
 #   GROUP  - optional example group such as "chat" or "audio". Only examples
 #            starting with the group name will be built.
 
@@ -17,7 +17,7 @@ mode="all"
 groups=()
 if [[ $# -gt 0 ]]; then
     case "$1" in
-        all|fast)
+        all|core)
             mode="$1"
             shift
             ;;
@@ -26,14 +26,6 @@ if [[ $# -gt 0 ]]; then
 fi
 
 cd "$EXAMPLES_DIR"
-
-fast_examples=(
-    chat
-    completion
-    embedding
-    moderation
-    responses
-)
 
 # Collect all example directories
 mapfile -t all_dirs < <(find . -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort)
@@ -52,13 +44,10 @@ for dir in "${all_dirs[@]}"; do
     fi
 
     if $include; then
-        if [[ "$mode" == "fast" ]]; then
-            for f in "${fast_examples[@]}"; do
-                if [[ "$dir" == "$f" ]]; then
-                    targets+=("$dir")
-                    break
-                fi
-            done
+        if [[ "$mode" == "core" ]]; then
+            if [[ "$dir" != *_* ]]; then
+                targets+=("$dir")
+            fi
         else
             targets+=("$dir")
         fi


### PR DESCRIPTION
## Summary
- rename `fast` mode to `core` in the example build script
- filter example directories without underscores when using `core`
- update workflow docs for the new `core` mode
- add reflection for the change

## Testing
- `dub run dfmt -- scripts/build_examples.sh` *(fails: no identifier for declarator)*
- `dub run dfmt -- AGENTS.md` *(fails: `(` expected)*
- `dub lint --dscanner-config dscanner.ini`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6850a0ced098832cb9fd92cc6ec08fd9