### PR TITLE
[administration] add audit log query filters

### DIFF
--- a/.agents/reflections/2025-06-16-2301-audit-log-time-range.md
+++ b/.agents/reflections/2025-06-16-2301-audit-log-time-range.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-16 23:01]
+  - **Task**: Add optional parameters to audit log request and tests
+  - **Objective**: Extend audit log search to filter by actor emails, resource IDs and effective time range
+  - **Outcome**: Implemented new struct, updated client serialization and added coverage tests
+
+#### :sparkles: What went well
+  - Refactoring query logic into a helper made it simple to test
+  - Existing project guidelines streamlined formatting and linting
+
+#### :warning: Pain points
+  - Building dependencies during lint took noticeable time on the CI container
+  - Understanding DUB single-file execution for quick debugging was not obvious
+
+#### :bulb: Proposed Improvement
+  - Provide a lightweight script to print constructed URLs for debugging without running full tests
+  - …

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -596,21 +596,62 @@ struct ListAuditLogsResponse
     @serdeKeys("has_more") bool hasMore;
 }
 
+struct AuditLogTimeRange
+{
+    @serdeOptional @serdeIgnoreDefault long gt;
+    @serdeOptional @serdeIgnoreDefault long gte;
+    @serdeOptional @serdeIgnoreDefault long lt;
+    @serdeOptional @serdeIgnoreDefault long lte;
+}
+
 struct ListAuditLogsRequest
 {
     @serdeOptional @serdeIgnoreDefault string[] projectIds;
     @serdeOptional @serdeIgnoreDefault string[] eventTypes;
     @serdeOptional @serdeIgnoreDefault string[] actorIds;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("actor_emails")
+    string[] actorEmails;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("resource_ids")
+    string[] resourceIds;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("effective_at")
+    AuditLogTimeRange effectiveAt;
     @serdeOptional @serdeIgnoreDefault uint limit;
     @serdeOptional @serdeIgnoreDefault string after;
     @serdeOptional @serdeIgnoreDefault string before;
 }
 
 /// Convenience constructor for `ListAuditLogsRequest`.
-ListAuditLogsRequest listAuditLogsRequest(uint limit)
+ListAuditLogsRequest listAuditLogsRequest(
+    uint limit,
+    string[] projectIds = null,
+    string[] eventTypes = null,
+    string[] actorIds = null,
+    string[] actorEmails = null,
+    string[] resourceIds = null,
+    AuditLogTimeRange effectiveAt = AuditLogTimeRange.init,
+    string after = "",
+    string before = "")
 {
     auto req = ListAuditLogsRequest();
     req.limit = limit;
+    if (projectIds !is null)
+        req.projectIds = projectIds;
+    if (eventTypes !is null)
+        req.eventTypes = eventTypes;
+    if (actorIds !is null)
+        req.actorIds = actorIds;
+    if (actorEmails !is null)
+        req.actorEmails = actorEmails;
+    if (resourceIds !is null)
+        req.resourceIds = resourceIds;
+    req.effectiveAt = effectiveAt;
+    if (after.length)
+        req.after = after;
+    if (before.length)
+        req.before = before;
     return req;
 }
 


### PR DESCRIPTION
## Summary
- expand `ListAuditLogsRequest` with additional filter fields
- add `AuditLogTimeRange` struct
- handle extra filters when constructing audit-log URLs
- expose helper `buildListAuditLogsUrl`
- test query-string encoding for new parameters
- document reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_6850a0dcebc8832c9acb8c8cc126f726