### PR TITLE
[administration] enum support for audit log actors

### DIFF
--- a/.agents/reflections/2025-06-17-1130-add-audit-log-enums.md
+++ b/.agents/reflections/2025-06-17-1130-add-audit-log-enums.md
@@ -1,0 +1,17 @@
+### :book: Reflection for [2025-06-17 11:30]
+  - **Task**: Introduce enums for audit log actor types
+  - **Objective**: Replace string fields with enums and ensure serialization works
+  - **Outcome**: Added new enum definitions, updated serialization attributes, and extended unit tests for round-tripping
+
+#### :sparkles: What went well
+  - mir.serde formatting automatically handled enum values
+  - Unit tests provided a quick regression check
+
+#### :warning: Pain points
+  - Setting up a temporary package to inspect serialization output was time-consuming
+  - mir.serde documentation was not readily accessible for enum proxy usage
+
+#### :bulb: Proposed Improvement
+  - Include a small example or script demonstrating mir.serde enum serialization to speed up debugging
+  - Add instructions in AGENTS.md on using dub's single-file mode for quick experiments
+


### PR DESCRIPTION
## Summary
- introduce `AuditLogActorType` and `AuditLogApiKeyType` enums
- replace string fields in `AuditLogActor` and `AuditLogActorApiKey`
- add tests verifying enum round‑tripping
- document development reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_68514f910b78832c8291f23e25bc7543