### PR TITLE
[administration] add certificate audit events

### DIFF
--- a/.agents/reflections/2025-06-17-1131-add-certificate-events.md
+++ b/.agents/reflections/2025-06-17-1131-add-certificate-events.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-17 11:31]
+- **Task**: Document audit log certificate events and update enum
+- **Objective**: Ensure Administration models match OpenAPI and note spec discrepancies
+- **Outcome**: Added certificate events to `AuditLogEventType`, updated tests, and confirmed formatting, linting, and examples build successfully
+
+#### :sparkles: What went well
+- Automated tooling (dfmt, linter, tests) ran smoothly and caught no issues
+- OpenAPI spec available online helped confirm official event list
+
+#### :warning: Pain points
+- Building example applications is slow in the container, increasing turnaround time
+
+#### :bulb: Proposed Improvement
+- Provide prebuilt example binaries or a cached build directory to speed up iterative example compilation

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -545,6 +545,13 @@ enum AuditLogEventType
     UserAdded = "user.added",
     UserUpdated = "user.updated",
     UserDeleted = "user.deleted",
+    /// Present in the AuditLog schema but missing from the official
+    /// `AuditLogEventType` enum in OpenAPI 2.3.0.
+    CertificateCreated = "certificate.created",
+    CertificateUpdated = "certificate.updated",
+    CertificateDeleted = "certificate.deleted",
+    CertificatesActivated = "certificates.activated",
+    CertificatesDeactivated = "certificates.deactivated",
 }
 
 @serdeIgnoreUnexpectedKeys
@@ -707,4 +714,16 @@ unittest
     assert(log.actor.session.ipAddress == "127.0.0.1");
     assert(log.apiKeyCreated.id == "key_xxxx");
     assert(log.apiKeyCreated.data.scopes[0] == "resource.operation");
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    enum exampleCert =
+        `{"id":"req_cert","type":"certificate.created","effective_at":1,"actor":{"type":"session","session":{"user":{"id":"user-cert","email":"cert@example.com"},"ip_address":"127.0.0.1"}},"certificate.created":{"id":"cert-abc","name":"my-cert"}}`;
+    auto log = deserializeJson!AuditLog(exampleCert);
+    assert(log.type == AuditLogEventType.CertificateCreated);
+    assert(log.certificateCreated.id == "cert-abc");
+    assert(log.certificateCreated.name == "my-cert");
 }


### PR DESCRIPTION
## Summary
- include certificate events in `AuditLogEventType`
- add unit test covering `certificate.created`
- document spec mismatch in reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `./scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_68514fc4fc38832c9f74afe4069523e8