### PR TITLE
[administration] fix test build and run sample builds

### DIFF
--- a/.agents/reflections/2025-06-17-1156-run-tests-and-build-samples.md
+++ b/.agents/reflections/2025-06-17-1156-run-tests-and-build-samples.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-17 11:56]
+- **Task**: Run tests and build samples
+- **Objective**: Ensure `dub test` and example builds succeed
+- **Outcome**: Added missing import to fix build failure; all tests and example builds now succeed
+
+#### :sparkles: What went well
+- Tools like `dub` provided clear error messages
+- Automated formatting and linting streamlined the workflow
+
+#### :warning: Pain points
+- Example build process is slow due to rebuilding dependencies
+- Coverage generation produces many temporary files
+
+#### :bulb: Proposed Improvement
+- Provide a pre-built cache of dependencies to speed up example builds

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -759,7 +759,7 @@ unittest
 unittest
 {
     import mir.deser.json : deserializeJson;
-  
+
     enum example =
         `{"id":"req_ja4","type":"login.succeeded","effective_at":0,"actor":{"type":"session","session":{"user":{"id":"user","email":"u@example.com"},"ip_address":"127.0.0.1","user_agent":"UA","ja3":"ja3hash","ja4":"ja4hash","ip_address_details":{"country":"US","city":"SF","region":"CA","region_code":"CA","asn":"1234","latitude":"37.77","longitude":"-122.42"}}}}`;
     auto log = deserializeJson!AuditLog(example);
@@ -801,6 +801,7 @@ unittest
 unittest
 {
     import mir.ser.json : serializeJson;
+    import mir.deser.json : deserializeJson;
 
     AuditLogActor actor;
     actor.type = AuditLogActorType.ApiKey;


### PR DESCRIPTION
## Summary
- add missing import in administration tests so dub test passes
- add a reflection about running tests and sample builds

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6851569ab884832cb58dc51ff2743787