### PR TITLE
[docs] mark audit logs complete

### DIFF
--- a/.agents/reflections/2025-06-17-1249-document-audit-logs-completion.md
+++ b/.agents/reflections/2025-06-17-1249-document-audit-logs-completion.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-17 12:49]
+  - **Task**: Mark audit logs as complete in README
+  - **Objective**: Document that the audit log API is ready for use
+  - **Outcome**: Updated checklist and added example snippet
+
+#### :sparkles: What went well
+  - Straightforward README edits
+  - Tests and formatting succeeded without issues
+
+#### :warning: Pain points
+  - Linter download adds noticeable delay
+  - Coverage generation slightly slows iteration
+
+#### :bulb: Proposed Improvement
+  - Cache linter binaries to speed up lint step

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [ ] Project service accounts (TODO)
   - [ ] Project API keys (TODO)
   - [ ] Project rate limits (TODO)
-  - [ ] Audit logs (WIP)
+  - [x] Audit logs
   - [ ] Usage (TODO)
   - [x] Certificates (TODO)
 
@@ -246,6 +246,15 @@ import openai;
 auto client = new OpenAIClient();
 auto list = client.listProjects(listProjectsRequest(20));
 writeln(list.data.length);
+```
+
+```d name=admin_audit_logs
+import std;
+import openai;
+
+auto client = new OpenAIClient();
+auto logs = client.listAuditLogs(listAuditLogsRequest(10));
+writeln(logs.data.length);
 ```
 
 


### PR DESCRIPTION
## Summary
- mark the Administration audit logs feature as done
- add example showing how to list audit logs
- record reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_685162870094832cad817b6e2e7302b3