### PR TITLE
[examples] admin API key management sample

### DIFF
--- a/.agents/reflections/2025-06-17-1326-add-admin-api-key-example.md
+++ b/.agents/reflections/2025-06-17-1326-add-admin-api-key-example.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-17 13:26]
+  - **Task**: Add administration API keys example
+  - **Objective**: Provide a sample demonstrating admin API key operations
+  - **Outcome**: Created new example folder with dub config and sample code; formatted, linted, tested, and built successfully.
+
+#### :sparkles: What went well
+  - Followed repository workflow to run formatter, linter, tests, and example build without issues.
+  - Understanding of existing examples made it straightforward to craft the new sample.
+
+#### :warning: Pain points
+  - `build_examples.sh core` skipped the new underscore-named example, requiring extra investigation.
+  - Running lint downloads dependencies each time, slowing iteration in the container environment.
+
+#### :bulb: Proposed Improvement
+  - Update `build_examples.sh` to build explicitly specified directories even when `core` mode is used, preventing confusion when working with underscore-named examples.

--- a/examples/administration_api_keys/.gitignore
+++ b/examples/administration_api_keys/.gitignore
@@ -1,0 +1,16 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/administration_api_keys
+administration_api_keys.so
+administration_api_keys.dylib
+administration_api_keys.dll
+administration_api_keys.a
+administration_api_keys.lib
+administration_api_keys-test-*
+*.exe
+*.pdb
+*.o
+*.obj
+*.lst

--- a/examples/administration_api_keys/dub.sdl
+++ b/examples/administration_api_keys/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_api_keys"
+description "Admin API key management example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_api_keys/dub.selections.json
+++ b/examples/administration_api_keys/dub.selections.json
@@ -1,0 +1,11 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/administration_api_keys/source/app.d
+++ b/examples/administration_api_keys/source/app.d
@@ -1,0 +1,17 @@
+import std.stdio;
+
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    auto created = client.createAdminApiKey(createAdminApiKeyRequest("Example Key"));
+    auto got = client.getAdminApiKey(created.id);
+    auto list = client.listAdminApiKeys(listAdminApiKeysRequest(20));
+    auto deleted = client.deleteAdminApiKey(created.id);
+
+    writeln(got.name);
+    writeln(list.data.length);
+    writeln(deleted.deleted);
+}


### PR DESCRIPTION
## Summary
- add new `administration_api_keys` example demonstrating admin API key management
- include reflection for the work

## Testing
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core administration_api_keys`


------
https://chatgpt.com/codex/tasks/task_e_68516bbc4f04832c9550575bbcd28cf8