### PR TITLE
[examples] add audit log query sample

### DIFF
--- a/.agents/reflections/2025-06-17-1326-add-audit-log-example.md
+++ b/.agents/reflections/2025-06-17-1326-add-audit-log-example.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-17 13:26]
+- **Task**: Add administration audit log example
+- **Objective**: Provide sample usage of `listAuditLogs` with filters
+- **Outcome**: Created new example folder and verified it builds alongside tests
+
+#### :sparkles: What went well
+- The existing example structure made duplication straightforward
+- Formatter and linter ran without issues
+
+#### :warning: Pain points
+- `build_examples.sh core` skipped the new folder because it contains an underscore
+- Example builds reinstall dependencies, slowing iteration
+
+#### :bulb: Proposed Improvement
+- Adjust the build script to respect explicit group arguments even in core mode

--- a/examples/administration_audit_logs/.gitignore
+++ b/examples/administration_audit_logs/.gitignore
@@ -1,0 +1,16 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/administration_audit_logs
+administration_audit_logs.so
+administration_audit_logs.dylib
+administration_audit_logs.dll
+administration_audit_logs.a
+administration_audit_logs.lib
+administration_audit_logs-test-*
+*.exe
+*.pdb
+*.o
+*.obj
+*.lst

--- a/examples/administration_audit_logs/dub.sdl
+++ b/examples/administration_audit_logs/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_audit_logs"
+description "Audit logs API example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_audit_logs/dub.selections.json
+++ b/examples/administration_audit_logs/dub.selections.json
@@ -1,0 +1,11 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/administration_audit_logs/source/app.d
+++ b/examples/administration_audit_logs/source/app.d
@@ -1,0 +1,12 @@
+import std.stdio;
+
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+    // Filter audit logs by event type
+    auto request = listAuditLogsRequest(20, null, ["login.failed"]);
+    auto logs = client.listAuditLogs(request);
+    writeln(logs.data.length);
+}


### PR DESCRIPTION
## Summary
- add `examples/administration_audit_logs` demonstrating how to filter audit logs
- document the task in a new reflection

## Testing
- `dub run dfmt -- source examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core administration_audit_logs` *(no output as folder contains an underscore)*
- `scripts/build_examples.sh administration_audit_logs`

------
https://chatgpt.com/codex/tasks/task_e_68516bbe022c832c85af00cdfc25e5a6