### PR TITLE
[examples] add certificate operations sample

### DIFF
--- a/.agents/reflections/2025-06-17-1325-certificate-operations-example.md
+++ b/.agents/reflections/2025-06-17-1325-certificate-operations-example.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-17 13:25]
+- **Task**: Add certificate operations example
+- **Objective**: Demonstrate use of certificate APIs in a standalone sample
+- **Outcome**: Created new `administration_certificates` example and verified formatting, linting, tests, and builds
+
+#### :sparkles: What went well
+- Dfmt, lint, and tests all ran without issues
+- Example compiled successfully once the build script command was clarified
+
+#### :warning: Pain points
+- `scripts/build_examples.sh core` skipped directories with underscores, which was confusing
+- Building examples remains time consuming
+
+#### :bulb: Proposed Improvement
+- Adjust build script to include specified groups even if they contain underscores
+- …

--- a/examples/administration_certificates/.gitignore
+++ b/examples/administration_certificates/.gitignore
@@ -1,0 +1,16 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/administration_certificates
+administration_certificates.so
+administration_certificates.dylib
+administration_certificates.dll
+administration_certificates.a
+administration_certificates.lib
+administration_certificates-test-*
+*.exe
+*.pdb
+*.o
+*.obj
+*.lst

--- a/examples/administration_certificates/dub.sdl
+++ b/examples/administration_certificates/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_certificates"
+description "Certificate operations example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_certificates/dub.selections.json
+++ b/examples/administration_certificates/dub.selections.json
@@ -1,0 +1,11 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/administration_certificates/source/app.d
+++ b/examples/administration_certificates/source/app.d
@@ -1,0 +1,28 @@
+module app;
+
+import std.stdio;
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    // List existing certificates
+    auto list = client.listCertificates();
+    writeln(list.data.length);
+
+    if (list.data.length > 0)
+    {
+        auto id = list.data[0].id;
+
+        // Activate the certificate
+        client.activateCertificates(toggleCertificatesRequest([id]));
+
+        // Update the certificate name
+        auto name = list.data[0].name;
+        client.modifyCertificate(id, modifyCertificateRequest(name));
+
+        // Deactivate the certificate
+        client.deactivateCertificates(toggleCertificatesRequest([id]));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `administration_certificates` example
- demonstrate certificate list, activation, modification and deactivation
- document workflow in new reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core administration_certificates`


------
https://chatgpt.com/codex/tasks/task_e_68516bbe7a04832c942e4d932e27cc10