### PR TITLE
[docs] mark invites WIP

### DIFF
--- a/.agents/reflections/2025-06-18-1047-mark-invites-wip.md
+++ b/.agents/reflections/2025-06-18-1047-mark-invites-wip.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 10:47]
+  - **Task**: Mark invites as work in progress
+  - **Objective**: Ensure README feature table matches project status
+  - **Outcome**: README updated and all checks passed
+
+#### :sparkles: What went well
+  - Simple documentation update with clear instructions
+  - Automated checks ensured repository consistency
+
+#### :warning: Pain points
+  - Build script generates many artifacts that require cleanup on every run
+  - Running full example builds is slow on constrained environments
+
+#### :bulb: Proposed Improvement
+  - Provide a cleanup command or script to remove build artifacts automatically

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
 - [ ] [Assistants (Beta)](https://platform.openai.com/docs/api-reference/assistants) (TODO)
 - [ ] [Administration](https://platform.openai.com/docs/api-reference/administration) (WIP)
   - [x] Admin API Keys
-  - [ ] Invites (TODO)
+  - [ ] Invites (WIP)
   - [ ] Users (TODO)
   - [x] Projects
   - [ ] Project users (TODO)


### PR DESCRIPTION
## Summary
- update README to show invites section is a WIP
- add reflection for this documentation update

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_68529851323c832c9d78b26f863cc447