### PR TITLE
[administration] add invite types

### DIFF
--- a/.agents/reflections/2025-06-18-1233-add-invite-types.md
+++ b/.agents/reflections/2025-06-18-1233-add-invite-types.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-18 12:33]
+  - **Task**: Add invite types
+  - **Objective**: Implement invite-related structs and tests from the OpenAPI schema
+  - **Outcome**: New structs added with passing tests
+
+#### :sparkles: What went well
+  - Access to the official OpenAPI spec made modeling straightforward
+  - Automated tools (dfmt, dscanner, dub test) ensured code quality
+
+#### :warning: Pain points
+  - Running small ad-hoc programs with dub was awkward due to single-file recipe syntax
+
+#### :bulb: Proposed Improvement
+  - Provide a helper script for quickly compiling and running snippets using the project's dependencies

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -141,6 +141,75 @@ ProjectUpdateRequest projectUpdateRequest(string name)
 }
 
 @serdeIgnoreUnexpectedKeys
+struct InviteProject
+{
+    string id;
+    string role;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct Invite
+{
+    string object;
+    string id;
+    string email;
+    string role;
+    string status;
+    @serdeKeys("invited_at") long invitedAt;
+    @serdeKeys("expires_at") long expiresAt;
+    @serdeOptional @serdeKeys("accepted_at") long acceptedAt;
+    @serdeOptional @serdeIgnoreDefault InviteProject[] projects;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct InviteListResponse
+{
+    string object;
+    Invite[] data;
+    @serdeKeys("first_id") string firstId;
+    @serdeKeys("last_id") string lastId;
+    @serdeKeys("has_more") bool hasMore;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct InviteDeleteResponse
+{
+    string object;
+    string id;
+    bool deleted;
+}
+
+struct ListInvitesRequest
+{
+    @serdeOptional @serdeIgnoreDefault uint limit;
+    @serdeOptional @serdeIgnoreDefault string after;
+}
+
+/// Convenience constructor for `ListInvitesRequest`.
+ListInvitesRequest listInvitesRequest(uint limit)
+{
+    auto req = ListInvitesRequest();
+    req.limit = limit;
+    return req;
+}
+
+struct InviteRequest
+{
+    string email;
+    string role;
+    @serdeOptional @serdeIgnoreDefault InviteProject[] projects;
+}
+
+/// Convenience constructor for `InviteRequest`.
+InviteRequest inviteRequest(string email, string role)
+{
+    auto req = InviteRequest();
+    req.email = email;
+    req.role = role;
+    return req;
+}
+
+@serdeIgnoreUnexpectedKeys
 struct CertificateDetails
 {
     @serdeKeys("valid_at") long validAt;
@@ -1028,4 +1097,18 @@ unittest
     enum example = `{"object":"page","data":[{"object":"bucket","start_time":1730419200,"end_time":1730505600,"result":[{"object":"organization.costs.result","amount":{"value":0.06,"currency":"usd"},"line_item":null,"project_id":null}]}],"has_more":false,"next_page":null}`;
     auto res = deserializeJson!UsageResponse(example);
     assert(res.data[0].results[0].get!CostsResult().amount.value == 0.06);
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+    import mir.ser.json : serializeJson;
+
+    enum example = `{"object":"list","data":[{"object":"organization.invite","id":"invite-abc","email":"user@example.com","role":"owner","status":"accepted","invited_at":1,"expires_at":2,"accepted_at":3}],"first_id":"invite-abc","last_id":"invite-abc","has_more":false}`;
+    auto list = deserializeJson!InviteListResponse(example);
+    assert(list.data.length == 1);
+    assert(list.data[0].id == "invite-abc");
+
+    auto req = inviteRequest("user@example.com", "owner");
+    assert(serializeJson(req) == `{"email":"user@example.com","role":"owner"}`);
 }


### PR DESCRIPTION
## Summary
- add Invite, InviteListResponse and related types
- add convenience constructors and unittest
- document reflection

## Testing
- `dub run dfmt -- source`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_6852b0520034832c8b4cbb56a57754e4