### PR TITLE
[examples] cleanup administration usage demo

### DIFF
--- a/.agents/reflections/2025-06-18-1232-admin-usage-example.md
+++ b/.agents/reflections/2025-06-18-1232-admin-usage-example.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 12:32]
+  - **Task**: Add administration usage example
+  - **Objective**: Demonstrate retrieval of usage data with listUsageCompletions and ensure builds succeed
+  - **Outcome**: Implemented a new example usage.d with corresponding configuration and verified builds, tests and formatting
+
+#### :sparkles: What went well
+  - The build script allowed verifying individual example packages easily
+  - Using DUB configurations kept existing examples intact while adding a new one
+
+#### :warning: Pain points
+  - Figuring out the correct SDLang syntax for configuration blocks was tricky and resulted in initial build failures
+  - Fetching documentation online required several attempts due to path uncertainty
+
+#### :bulb: Proposed Improvement
+  - Add a local examples/dub.sdl snippet documenting multi-configuration syntax to speed up future additions

--- a/.agents/reflections/2025-06-18-1243-admin-usage-gitignore.md
+++ b/.agents/reflections/2025-06-18-1243-admin-usage-gitignore.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-18 12:43]
+  - **Task**: adjust administration usage example
+  - **Objective**: Remove unnecessary dub.sdl config and add gitignore entries
+  - **Outcome**: Simplified the administration package to avoid build conflicts and added ignore rules for the new usage sample
+
+#### :sparkles: What went well
+  - The build script quickly confirmed multiple mains would fail
+  - Restoring the original dub.sdl was straightforward with git checkout
+
+#### :warning: Pain points
+  - Manually cleaning the generated libopenai-d.a after test runs is easy to forget and clutters git status
+
+#### :bulb: Proposed Improvement
+  - Add a cleanup step to the build/test scripts that removes stray artifacts like libopenai-d.a

--- a/examples/administration/.gitignore
+++ b/examples/administration/.gitignore
@@ -9,6 +9,14 @@ administration.dll
 administration.a
 administration.lib
 administration-test-*
+
+/usage
+usage.so
+usage.dylib
+usage.dll
+usage.a
+usage.lib
+usage-test-*
 *.exe
 *.pdb
 *.o

--- a/examples/administration/source/usage.d
+++ b/examples/administration/source/usage.d
@@ -1,0 +1,15 @@
+import std.stdio;
+
+import openai;
+
+/// Simple helper demonstrating the Usage API.
+void runUsageExample()
+{
+    auto client = new OpenAIClient();
+
+    auto req = listUsageRequest(0);
+    req.limit = 3;
+
+    auto usage = client.listUsageCompletions(req);
+    writeln(usage.data.length);
+}


### PR DESCRIPTION
## Summary
- add a simple `runUsageExample` helper
- ignore the resulting binary in `.gitignore`
- revert `dub.sdl` back to its original form
- document changes with a reflection

## Testing
- `dub run dfmt -- examples`
- `dub run dfmt -- source`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core administration`


------
https://chatgpt.com/codex/tasks/task_e_6852b0156e68832c80f48628e1c8206f