### PR TITLE
[client] support invite administration

### DIFF
--- a/.agents/reflections/2025-06-18-1246-support-invite-admin.md
+++ b/.agents/reflections/2025-06-18-1246-support-invite-admin.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-18 12:46]
+  - **Task**: Add invite administration methods
+  - **Objective**: Implement list, create, retrieve and delete invite APIs
+  - **Outcome**: Added client methods with URL builder and tests
+
+#### :sparkles: What went well
+  - Reused existing helper patterns for consistent query handling
+  - Automated formatting and tests ensured code quality
+
+#### :warning: Pain points
+  - Linting downloads dependencies every run which is slow in the container
+  - Numerous deprecation warnings during example builds clutter logs
+
+#### :bulb: Proposed Improvement
+  - Provide cached dscanner binaries and silence deprecation warnings in scripts
+  - 


### PR DESCRIPTION
## Summary
- add invite administration helpers to `OpenAIClient`
- expose `buildListInvitesUrl` for constructing query strings
- test invite URL builder
- document the experience in a reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6852b38f38e8832c81e430a6372932d0