### PR TITLE
[docs] document admin usage request

### DIFF
--- a/.agents/reflections/2025-06-18-1322-admin-usage-readme.md
+++ b/.agents/reflections/2025-06-18-1322-admin-usage-readme.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 13:22]
+  - **Task**: Update README administration usage section
+  - **Objective**: Document usage endpoint and mark as implemented
+  - **Outcome**: Added code snippet and updated checklist entry
+
+#### :sparkles: What went well
+  - Easy to locate existing examples to copy
+  - Automation checks passed quickly
+
+#### :warning: Pain points
+  - Example build produced extra artifacts needing cleanup
+  - Dfmt and linter downloads slowed the workflow
+
+#### :bulb: Proposed Improvement
+  - Adjust build script to avoid creating artifacts when building docs

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [ ] Project API keys (TODO)
   - [ ] Project rate limits (TODO)
   - [x] Audit logs
-  - [ ] Usage (TODO)
+  - [x] Usage
   - [x] Certificates
 
 __legacy__
@@ -271,6 +271,19 @@ auto client = new OpenAIClient();
 auto logs = client.listAuditLogs(listAuditLogsRequest(10));
 writeln(logs.data.length);
 ```
+
+```d name=admin_usage
+import std;
+import openai;
+
+auto client = new OpenAIClient();
+auto req = listUsageRequest(0);
+req.limit = 3;
+auto usage = client.listUsageCompletions(req);
+writeln(usage.data.length);
+```
+
+Requires an admin API key. See `examples/administration` for a complete example.
 
 
 ## OpenAIClientConfig


### PR DESCRIPTION
## Summary
- mark admin usage support as implemented in the feature table
- show how to call the usage endpoint
- note that an admin API key is required and reference example directory
- record reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6852bc89f930832c8cb48ad9916c7977