### PR TITLE
[examples] add administration invites

### DIFF
--- a/.agents/reflections/2025-06-18-1321-administration_invites-example.md
+++ b/.agents/reflections/2025-06-18-1321-administration_invites-example.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-18 13:21]
+  - **Task**: Add administration_invites example
+  - **Objective**: Provide a sample showing invite management
+  - **Outcome**: New example compiled successfully after running all checks
+
+#### :sparkles: What went well
+  - Following existing examples made creating the new one straightforward
+  - Formatter, linter, tests, and coverage all ran without issues
+
+#### :warning: Pain points
+  - `build_examples.sh core` ignored the underscore-named directory, leading to confusion
+  - Linting downloads dependencies each run, which slows feedback in the container
+
+#### :bulb: Proposed Improvement
+  - Update `build_examples.sh` to include explicitly provided directories even in core mode
+  - Cache linter dependencies to speed up repeated runs

--- a/.agents/reflections/2025-06-18-1330-administration_invites-uniformity.md
+++ b/.agents/reflections/2025-06-18-1330-administration_invites-uniformity.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 13:30]
+  - **Task**: Adjust administration_invites example
+  - **Objective**: Align new example with others and satisfy review feedback
+  - **Outcome**: Added missing `.gitignore` and updated README; all checks pass
+
+#### :sparkles: What went well
+  - The uniform .gitignore template made it easy to add the missing file
+  - Running formatter and build scripts confirmed the example works
+
+#### :warning: Pain points
+  - `scripts/build_examples.sh core administration_invites` still skips underscore directories, leading to confusion
+  - Linting downloads dependencies each run, slowing feedback in the container
+
+#### :bulb: Proposed Improvement
+  - Update `build_examples.sh` to build explicitly specified directories regardless of underscores

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
 - [ ] [Assistants (Beta)](https://platform.openai.com/docs/api-reference/assistants) (TODO)
 - [ ] [Administration](https://platform.openai.com/docs/api-reference/administration) (WIP)
   - [x] Admin API Keys
-  - [ ] Invites (WIP)
+  - [x] Invites
   - [ ] Users (TODO)
   - [x] Projects
   - [ ] Project users (TODO)

--- a/examples/administration_invites/.gitignore
+++ b/examples/administration_invites/.gitignore
@@ -1,0 +1,16 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/administration_invites
+administration_invites.so
+administration_invites.dylib
+administration_invites.dll
+administration_invites.a
+administration_invites.lib
+administration_invites-test-*
+*.exe
+*.pdb
+*.o
+*.obj
+*.lst

--- a/examples/administration_invites/dub.sdl
+++ b/examples/administration_invites/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_invites"
+description "Organization invites example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_invites/dub.selections.json
+++ b/examples/administration_invites/dub.selections.json
@@ -1,0 +1,11 @@
+{
+        "fileVersion": 1,
+        "versions": {
+                "mir-algorithm": "3.22.3",
+                "mir-core": "1.7.1",
+                "mir-cpuid": "1.2.11",
+                "mir-ion": "2.3.4",
+                "openai-d": {"path":"../.."},
+                "silly": "1.1.1"
+        }
+}

--- a/examples/administration_invites/source/app.d
+++ b/examples/administration_invites/source/app.d
@@ -1,0 +1,20 @@
+import std.stdio;
+
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    // List existing invites
+    auto list = client.listInvites(listInvitesRequest(20));
+    writeln(list.data.length);
+
+    // Create an invite
+    auto created = client.createInvite(inviteRequest("user@example.com", "owner"));
+    writeln(created.email);
+
+    // Delete the invite
+    auto deleted = client.deleteInvite(created.id);
+    writeln(deleted.deleted);
+}


### PR DESCRIPTION
## Summary
- add .gitignore for administration_invites example
- mark invites support as done in README
- document reflection about addressing review comments

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core administration`
- `scripts/build_examples.sh administration_invites`


------
https://chatgpt.com/codex/tasks/task_e_6852bc7b6650832cacedd73c5b14b3cd