### PR TITLE
[examples] add administration usage demo

### DIFF
--- a/.agents/reflections/2025-06-18-1352-administration-usage-example.md
+++ b/.agents/reflections/2025-06-18-1352-administration-usage-example.md
@@ -1,0 +1,17 @@
+### :book: Reflection for [2025-06-18 13:52]
+  - **Task**: Add administration_usage example
+  - **Objective**: Provide sample usage of the administration Usage API
+  - **Outcome**: Created new example and verified build script covers it
+
+#### :sparkles: What went well
+  - Simple code reuse from existing examples
+  - Build and tests all ran without issues
+
+#### :warning: Pain points
+  - The build script's `core` mode skips directories with underscores, so running
+    it as instructed did not build the new example at first.
+  - Fetching packages for formatter and linter still adds noticeable time.
+
+#### :bulb: Proposed Improvement
+  - Document that examples with underscores require using the `all` mode when
+    calling `build_examples.sh`.

--- a/examples/administration_usage/dub.sdl
+++ b/examples/administration_usage/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_usage"
+description "Usage reporting example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_usage/dub.selections.json
+++ b/examples/administration_usage/dub.selections.json
@@ -1,0 +1,11 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/administration_usage/source/app.d
+++ b/examples/administration_usage/source/app.d
@@ -1,0 +1,15 @@
+import std.stdio;
+
+import openai;
+
+/// Demonstrate the Administration Usage API.
+void main()
+{
+    auto client = new OpenAIClient();
+
+    auto req = listUsageRequest(0);
+    req.limit = 3;
+
+    auto completions = client.listUsageCompletions(req);
+    writeln(completions.data.length);
+}


### PR DESCRIPTION
## Summary
- add `administration_usage` example
- document a reflection about the build script behavior

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh all administration_usage`


------
https://chatgpt.com/codex/tasks/task_e_6852c3731650832c8e2d33a96c27ad43