### PR TITLE
[docs] document invite API

### DIFF
--- a/.agents/reflections/2025-06-18-1354-document-invite-api.md
+++ b/.agents/reflections/2025-06-18-1354-document-invite-api.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 13:54]
+- **Task**: document invite API
+- **Objective**: update README with invites snippet and example directory
+- **Outcome**: README now shows how to list invites and references the new example
+
+#### :sparkles: What went well
+- Formatting and tests ran smoothly
+- Build examples script confirmed unchanged functionality
+
+#### :warning: Pain points
+- `build_examples.sh` spewed deprecation warnings, slowing logs
+- linter initialization required repeated downloads, taking time
+
+#### :bulb: Proposed Improvement
+- Cache dependencies for tooling to reduce wait time

--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ auto list = client.listProjects(listProjectsRequest(20));
 writeln(list.data.length);
 ```
 
+```d name=admin_invites
+import std;
+import openai;
+
+auto client = new OpenAIClient();
+auto list = client.listInvites(listInvitesRequest(20));
+writeln(list.data.length);
+```
+
 ```d name=admin_audit_logs
 import std;
 import openai;
@@ -283,7 +292,8 @@ auto usage = client.listUsageCompletions(req);
 writeln(usage.data.length);
 ```
 
-Requires an admin API key. See `examples/administration` for a complete example.
+Requires an admin API key. See `examples/administration` and
+`examples/administration_invites` for complete examples.
 
 
 ## OpenAIClientConfig


### PR DESCRIPTION
## Summary
- show how to list invites in README
- add link to `examples/administration_invites`
- add reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6852c3ac6b8c832c81023afc0bc2dadf