### PR TITLE
[docs] clarify build examples underscore handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,13 @@
       ```bash
       scripts/build_examples.sh core
       ```
+      * `core` intentionally skips directories containing underscores. Use the
+        `all` mode to build them manually. For example, to build the
+        `administration_invites` examples:
+
+        ```bash
+        scripts/build_examples.sh all administration_invites
+        ```
    3. To mirror CI or prepare a full release, you can still build **all**:
 
       ```bash


### PR DESCRIPTION
## Summary
- document that scripts/build_examples.sh core skips underscore directories
- add usage example for building such directories with 'all'

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`
- `scripts/build_examples.sh all administration_invites`


------
https://chatgpt.com/codex/tasks/task_e_6852c3dfbe0c832c8cbde02326b7d43d