### PR TITLE
[examples] remove leftover silly dependency

### DIFF
--- a/.agents/reflections/2025-06-18-1417-remove-silly-dependency.md
+++ b/.agents/reflections/2025-06-18-1417-remove-silly-dependency.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 14:17]
+  - **Task**: Remove obsolete 'silly' dependency lines
+  - **Objective**: Clean up example config files and ensure build passes
+  - **Outcome**: Deleted all references to the unused dependency and verified the full workflow
+
+#### :sparkles: What went well
+  - Automated sed commands made editing many files quick
+  - Build scripts ran without issues once configs were fixed
+
+#### :warning: Pain points
+  - Building every example took a long time and produced lots of warnings
+  - Linter fetches extra dependencies, causing noise in logs
+
+#### :bulb: Proposed Improvement
+  - Consider caching built dependencies during CI to speed up repeated example builds

--- a/examples/administration/dub.selections.json
+++ b/examples/administration/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/administration_api_keys/dub.selections.json
+++ b/examples/administration_api_keys/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/administration_audit_logs/dub.selections.json
+++ b/examples/administration_audit_logs/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/administration_certificates/dub.selections.json
+++ b/examples/administration_certificates/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/administration_invites/dub.selections.json
+++ b/examples/administration_invites/dub.selections.json
@@ -1,11 +1,10 @@
 {
-        "fileVersion": 1,
-        "versions": {
-                "mir-algorithm": "3.22.3",
-                "mir-core": "1.7.1",
-                "mir-cpuid": "1.2.11",
-                "mir-ion": "2.3.4",
-                "openai-d": {"path":"../.."},
-                "silly": "1.1.1"
-        }
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."}
+	}
 }

--- a/examples/administration_projects/dub.selections.json
+++ b/examples/administration_projects/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/administration_usage/dub.selections.json
+++ b/examples/administration_usage/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/audio_speech/dub.selections.json
+++ b/examples/audio_speech/dub.selections.json
@@ -1,11 +1,10 @@
 {
-        "fileVersion": 1,
-        "versions": {
-                "mir-algorithm": "3.22.3",
-                "mir-core": "1.7.1",
-                "mir-cpuid": "1.2.11",
-                "mir-ion": "2.3.4",
-                "openai-d": {"path":"../.."},
-                "silly": "1.1.1"
-        }
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."}
+	}
 }

--- a/examples/audio_transcription/dub.selections.json
+++ b/examples/audio_transcription/dub.selections.json
@@ -1,11 +1,10 @@
 {
-        "fileVersion": 1,
-        "versions": {
-                "mir-algorithm": "3.22.3",
-                "mir-core": "1.7.1",
-                "mir-cpuid": "1.2.11",
-                "mir-ion": "2.3.4",
-                "openai-d": {"path":"../.."},
-                "silly": "1.1.1"
-        }
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."}
+	}
 }

--- a/examples/audio_translation/dub.selections.json
+++ b/examples/audio_translation/dub.selections.json
@@ -1,11 +1,10 @@
 {
-        "fileVersion": 1,
-        "versions": {
-                "mir-algorithm": "3.22.3",
-                "mir-core": "1.7.1",
-                "mir-cpuid": "1.2.11",
-                "mir-ion": "2.3.4",
-                "openai-d": {"path":"../.."},
-                "silly": "1.1.1"
-        }
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."}
+	}
 }

--- a/examples/chat/dub.selections.json
+++ b/examples/chat/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/chat_db/dub.selections.json
+++ b/examples/chat_db/dub.selections.json
@@ -6,7 +6,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/chat_reasoning/dub.selections.json
+++ b/examples/chat_reasoning/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/chat_structured_output/dub.selections.json
+++ b/examples/chat_structured_output/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/chat_tools/dub.selections.json
+++ b/examples/chat_tools/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/chat_vision/dub.selections.json
+++ b/examples/chat_vision/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/completion/dub.selections.json
+++ b/examples/completion/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/embedding/dub.selections.json
+++ b/examples/embedding/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/models/dub.selections.json
+++ b/examples/models/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/moderation/dub.selections.json
+++ b/examples/moderation/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/responses/dub.selections.json
+++ b/examples/responses/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/responses_code_interpreter/dub.selections.json
+++ b/examples/responses_code_interpreter/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.1",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }

--- a/examples/responses_web_search/dub.selections.json
+++ b/examples/responses_web_search/dub.selections.json
@@ -5,7 +5,6 @@
 		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."},
-		"silly": "1.1.1"
+		"openai-d": {"path":"../.."}
 	}
 }


### PR DESCRIPTION
## Summary
- clean up unused `silly` dependency in example `dub.selections.json` files
- add reflection record for this work

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh all`

------
https://chatgpt.com/codex/tasks/task_e_6852c8acdc34832c9d00c5cb49026714