### PR TITLE
[client] drop before query param from file list

### DIFF
--- a/.agents/reflections/2025-06-18-2207-drop-before-field.md
+++ b/.agents/reflections/2025-06-18-2207-drop-before-field.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-18 22:07]
+  - **Task**: Remove deprecated "before" parameter
+  - **Objective**: Update ListFiles API to drop obsolete query parameter and adjust tests
+  - **Outcome**: Implemented changes, all checks pass
+
+#### :sparkles: What went well
+  - Running dfmt, lint and tests was straightforward
+  - Automated tooling caught missing code removal quickly
+
+#### :warning: Pain points
+  - Initial test run failed because old code references remained
+  - Compiling with large dependencies makes linter start slowly
+
+#### :bulb: Proposed Improvement
+  - Provide helper scripts to automatically run formatter, linter and tests together
+  - …

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -1185,8 +1185,6 @@ class OpenAIClient
             url ~= format("%slimit=%s", sep, request.limit), sep = "&";
         if (request.after.length)
             url ~= format("%safter=%s", sep, encodeComponent(request.after)), sep = "&";
-        if (request.before.length)
-            url ~= format("%sbefore=%s", sep, encodeComponent(request.before));
         return url;
     }
 
@@ -1270,8 +1268,7 @@ class OpenAIClient
             url ~= format("%sorder=%s", sep, encodeComponent(request.order)), sep = "&";
         if (request.after.length)
             url ~= format("%safter=%s", sep, encodeComponent(request.after)), sep = "&";
-        if (request.before.length)
-            url ~= format("%sbefore=%s", sep, encodeComponent(request.before));
+        // 'before' parameter removed in API; no longer supported
         return url;
     }
 
@@ -1844,16 +1841,13 @@ unittest
     auto url = client.buildListFilesUrl(req);
 
     assert(!url.canFind("after="));
-    assert(!url.canFind("before="));
 
     req.after = "a";
     url = client.buildListFilesUrl(req);
     assert(url.canFind("after=a"));
 
     req.after = "";
-    req.before = "b";
     url = client.buildListFilesUrl(req);
-    assert(url.canFind("before=b"));
     assert(!url.canFind("after="));
 }
 
@@ -1869,12 +1863,10 @@ unittest
     auto req = listFilesRequest();
     req.purpose = "fine tune";
     req.after = "foo bar";
-    req.before = "bar+baz";
     auto url = client.buildListFilesUrl(req);
 
     assert(url.canFind("purpose=fine%20tune"));
     assert(url.canFind("after=foo%20bar"));
-    assert(url.canFind("before=bar%2Bbaz"));
 }
 
 @("buildListUsageUrl encodes query parameters")

--- a/source/openai/files.d
+++ b/source/openai/files.d
@@ -53,7 +53,6 @@ struct ListFilesRequest
     @serdeOptional @serdeIgnoreDefault size_t limit = 10_000;
     @serdeOptional @serdeIgnoreDefault string order = "desc";
     @serdeOptional @serdeIgnoreDefault string after;
-    @serdeOptional @serdeIgnoreDefault string before;
 }
 
 /// Convenience constructor for `ListFilesRequest`.


### PR DESCRIPTION
## Summary
- remove `before` field from `ListFilesRequest`
- stop encoding `before` query value in `buildListFilesUrl`
- update ListFiles tests accordingly
- add reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_685337843bdc832c9136f808b2c59a30