### PR TITLE
[examples] extend files demo

### DIFF
--- a/.agents/reflections/2025-06-18-2207-files-example-operations.md
+++ b/.agents/reflections/2025-06-18-2207-files-example-operations.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-18 22:07]
+  - **Task**: Extend files example to demonstrate more operations
+  - **Objective**: Provide complete usage sample covering file retrieval, download, and deletion
+  - **Outcome**: Added new code to `examples/files/source/app.d` and verified compilation
+
+#### :sparkles: What went well
+  - Example was straightforward to update using existing API methods
+  - Build script quickly confirmed compilation without needing to run the API
+
+#### :warning: Pain points
+  - Running linter and formatter each time still requires downloading dependencies, which is slow in this environment
+
+#### :bulb: Proposed Improvement
+  - Cache Dub dependencies in the CI or container to avoid repeated fetches during development

--- a/examples/files/source/app.d
+++ b/examples/files/source/app.d
@@ -1,11 +1,24 @@
 import std.stdio;
+import std.file : write;
+
 import openai;
 
 void main()
 {
     auto client = new OpenAIClient();
     auto req = fileUploadRequest("input.jsonl", FilePurpose.FineTune);
-    client.uploadFile(req);
+    auto uploaded = client.uploadFile(req);
+
     auto list = client.listFiles(listFilesRequest());
-    writeln(list.data.length);
+    writeln("files: ", list.data.length);
+
+    auto file = client.retrieveFile(uploaded.id);
+    writeln("retrieved: ", file.filename);
+
+    auto content = client.downloadFileContent(uploaded.id);
+    write("file-content.jsonl", content);
+    writeln("downloaded: ", content.length, " bytes");
+
+    auto res = client.deleteFile(uploaded.id);
+    writeln("deleted: ", res.deleted);
 }


### PR DESCRIPTION
## Summary
- demonstrate retrieving, downloading and deleting a file in files example
- add corresponding reflection entry

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core files`


------
https://chatgpt.com/codex/tasks/task_e_6853378ed8e8832cbe992ab712fb2b55