### PR TITLE
[files] add DeleteFileResponse deserialization test

### DIFF
--- a/.agents/reflections/2025-06-18-2208-add-delete-file-response-test.md
+++ b/.agents/reflections/2025-06-18-2208-add-delete-file-response-test.md
@@ -13,4 +13,3 @@
 
 #### :bulb: Proposed Improvement
   - Provide a cleaned example build mode that avoids generating `dub.selections.json` or binaries to reduce cleanup effort
-  - …

--- a/.agents/reflections/2025-06-18-2208-add-delete-file-response-test.md
+++ b/.agents/reflections/2025-06-18-2208-add-delete-file-response-test.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-18 22:08]
+  - **Task**: Add unittest for DeleteFileResponse
+  - **Objective**: Ensure delete-file responses deserialize correctly
+  - **Outcome**: Added test and confirmed all checks pass
+
+#### :sparkles: What went well
+  - Straightforward test addition and automation
+  - Project's scripts built examples without issues once run fully
+
+#### :warning: Pain points
+  - Example builds generate many temporary artifacts requiring cleanup
+  - Build output is quite verbose, making it hard to know when it completes
+
+#### :bulb: Proposed Improvement
+  - Provide a cleaned example build mode that avoids generating `dub.selections.json` or binaries to reduce cleanup effort
+  - …

--- a/source/openai/files.d
+++ b/source/openai/files.d
@@ -143,3 +143,14 @@ unittest
     assert(list.firstId == "file-1");
     assert(!list.hasMore);
 }
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    enum json = `{"id":"file-123","object":"file","deleted":true}`;
+    auto resp = deserializeJson!DeleteFileResponse(json);
+    assert(resp.id == "file-123");
+    assert(resp.object == "file");
+    assert(resp.deleted);
+}


### PR DESCRIPTION
## Summary
- add new unit test for DeleteFileResponse
- document task reflection

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`

------
https://chatgpt.com/codex/tasks/task_e_685337a2a7cc832ca38c55650aa1acc6