### PR TITLE
[docs] mark project api keys as wip

### DIFF
--- a/.agents/reflections/2025-06-18-2231-update-readme-administration-list.md
+++ b/.agents/reflections/2025-06-18-2231-update-readme-administration-list.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 22:31]
+  - **Task**: Update README administration bullet
+  - **Objective**: Change wording for project API keys entry
+  - **Outcome**: README entry updated and all checks run
+
+#### :sparkles: What went well
+  - Formatting and linter ran without errors
+  - Build script and tests completed successfully
+
+#### :warning: Pain points
+  - Example builds output many deprecation warnings, slowing down logs
+
+#### :bulb: Proposed Improvement
+  - Reduce build verbosity or address deprecations to speed up example compilation
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [x] Projects
   - [ ] Project users (TODO)
   - [ ] Project service accounts (TODO)
-  - [ ] Project API keys (TODO)
+  - [ ] Project API keys (WIP)
   - [ ] Project rate limits (TODO)
   - [x] Audit logs
   - [x] Usage


### PR DESCRIPTION
## Summary
- update README to indicate project API keys are WIP
- add reflection for this change

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`

------
https://chatgpt.com/codex/tasks/task_e_68533d901660832ca4ca1b2fcafcc676