### PR TITLE
[administration] add project API key structs

### DIFF
--- a/.agents/reflections/2025-06-18-2237-project-api-keys-support.md
+++ b/.agents/reflections/2025-06-18-2237-project-api-keys-support.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-18 22:37]
+  - **Task**: Add project API key structs and tests
+  - **Objective**: Implement missing data types for project API key management
+  - **Outcome**: Added new structs with convenience constructors and unit tests. All checks and builds succeed.
+
+#### :sparkles: What went well
+  - OpenAPI spec provided the schema so implementation was straightforward.
+  - Automation via dfmt, linter, tests, and example builds ensured consistency.
+
+#### :warning: Pain points
+  - Fetching dependencies during linting and example builds was slow in the container environment.
+  - Navigating large YAML spec to find schema sections was cumbersome.
+
+#### :bulb: Proposed Improvement
+  - Provide a local cached copy of the OpenAPI spec and frequently used packages to speed up development steps.
+  - Add helper scripts for quickly searching schema definitions.

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -141,6 +141,77 @@ ProjectUpdateRequest projectUpdateRequest(string name)
 }
 
 @serdeIgnoreUnexpectedKeys
+struct ProjectApiKey
+{
+    string object;
+    string id;
+    string name;
+    @serdeKeys("redacted_value") string redactedValue;
+    @serdeKeys("created_at") long createdAt;
+    @serdeKeys("last_used_at") long lastUsedAt;
+    @serdeOptional OwnerInfo owner;
+    @serdeOptional string value;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectApiKeyListResponse
+{
+    string object;
+    ProjectApiKey[] data;
+    @serdeKeys("first_id") string firstId;
+    @serdeKeys("last_id") string lastId;
+    @serdeKeys("has_more") bool hasMore;
+}
+
+struct ListProjectApiKeysRequest
+{
+    @serdeOptional @serdeIgnoreDefault uint limit;
+    @serdeOptional @serdeIgnoreDefault string after;
+}
+
+/// Convenience constructor for `ListProjectApiKeysRequest`.
+ListProjectApiKeysRequest listProjectApiKeysRequest(uint limit)
+{
+    auto req = ListProjectApiKeysRequest();
+    req.limit = limit;
+    return req;
+}
+
+struct CreateProjectApiKeyRequest
+{
+    string name;
+}
+
+/// Convenience constructor for `CreateProjectApiKeyRequest`.
+CreateProjectApiKeyRequest createProjectApiKeyRequest(string name)
+{
+    auto req = CreateProjectApiKeyRequest();
+    req.name = name;
+    return req;
+}
+
+struct ModifyProjectApiKeyRequest
+{
+    string name;
+}
+
+/// Convenience constructor for `ModifyProjectApiKeyRequest`.
+ModifyProjectApiKeyRequest modifyProjectApiKeyRequest(string name)
+{
+    auto req = ModifyProjectApiKeyRequest();
+    req.name = name;
+    return req;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct DeleteProjectApiKeyResponse
+{
+    string object;
+    string id;
+    bool deleted;
+}
+
+@serdeIgnoreUnexpectedKeys
 struct InviteProject
 {
     string id;
@@ -1111,4 +1182,39 @@ unittest
 
     auto req = inviteRequest("user@example.com", "owner");
     assert(serializeJson(req) == `{"email":"user@example.com","role":"owner"}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = listProjectApiKeysRequest(5);
+    assert(serializeJson(req) == `{"limit":5}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = createProjectApiKeyRequest("My Key");
+    assert(serializeJson(req) == `{"name":"My Key"}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = modifyProjectApiKeyRequest("New Name");
+    assert(serializeJson(req) == `{"name":"New Name"}`);
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    enum example =
+        `{"object":"list","data":[{"object":"organization.project.api_key","id":"key_abc","name":"Key","redacted_value":"sk-abc","created_at":1,"last_used_at":2,"owner":{"type":"user","id":"user_abc","name":"Owner"}}],"first_id":"key_abc","last_id":"key_abc","has_more":false}`;
+    auto list = deserializeJson!ProjectApiKeyListResponse(example);
+    assert(list.data.length == 1);
+    assert(list.data[0].id == "key_abc");
 }


### PR DESCRIPTION
## Summary
- support project API keys with new structs and helpers
- cover serialization with unit tests
- add development reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_68533d935f6c832c99ca062a4bc49c10