### PR TITLE
[docs] expand files api snippet

### DIFF
--- a/.agents/reflections/2025-06-18-2253-expand-files-readme.md
+++ b/.agents/reflections/2025-06-18-2253-expand-files-readme.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-18 22:53]
+  - **Task**: Expand Files API README snippet
+  - **Objective**: Show retrieval, download and deletion operations
+  - **Outcome**: README updated with full flow and all checks executed
+
+#### :sparkles: What went well
+  - Formatting and linting produced no diffs
+  - Tests, coverage and example builds succeeded
+
+#### :warning: Pain points
+  - Example build step is slow due to many deprecation warnings
+
+#### :bulb: Proposed Improvement
+  - Investigate caching or parallelizing example builds to speed up CI

--- a/README.md
+++ b/README.md
@@ -167,17 +167,25 @@ writeln(embedding.length); // text-embedding-3-small -> 1536
 __Files__
 
 ```d name=files
-import std;
+import std.stdio;
+import std.file : write;
 import openai;
 
 auto client = new OpenAIClient();
 auto up = fileUploadRequest("input.jsonl", FilePurpose.FineTune);
-client.uploadFile(up);
-auto list = client.listFiles(listFilesRequest());
-writeln(list.data.length);
+auto uploaded = client.uploadFile(up);
+
+auto retrieved = client.retrieveFile(uploaded.id);
+writeln("retrieved: ", retrieved.filename);
+
+auto content = client.downloadFileContent(uploaded.id);
+write("copy.jsonl", content);
+
+client.deleteFile(uploaded.id);
 ```
 
-See `examples/files` for a complete example.
+See `examples/files` for a complete example showing upload, retrieval, download,
+and deletion.
 
 __Moderation__
 


### PR DESCRIPTION
## Summary
- show retrieving, downloading and deleting uploaded files in the README
- point readers to the files example project
- add reflection on updating the README

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `dub lint --dscanner-config dscanner.ini`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_68534264d7f0832cb5cafb0c17e2e25d