### PR TITLE
[clients] add project API key endpoints

### DIFF
--- a/.agents/reflections/2025-06-18-2257-project-api-key-endpoints.md
+++ b/.agents/reflections/2025-06-18-2257-project-api-key-endpoints.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-18 22:57]
+  - **Task**: implement project api key endpoints
+  - **Objective**: expose project API key management in client
+  - **Outcome**: added methods and verified tests/builds pass
+
+#### :sparkles: What went well
+  - following existing patterns made implementation straightforward
+  - automated formatting and linting caught no issues
+
+#### :warning: Pain points
+  - unclear API URL structure required assumptions
+  - coverage generation produced many .lst files cluttering output
+
+#### :bulb: Proposed Improvement
+  - include API documentation links or specs in repo to clarify endpoints
+  - add cleanup step for coverage artifacts in CI scripts


### PR DESCRIPTION
## Summary
- expose project API key management functions
- add reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6853424b02e4832c87a9072633a67851