### PR TITLE
[docs] mark files api implemented

### DIFF
--- a/.agents/reflections/2025-06-18-2258-files-api-checklist.md
+++ b/.agents/reflections/2025-06-18-2258-files-api-checklist.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-18 22:58]
+  - **Task**: Mark Files API implemented
+  - **Objective**: Update README API checklist entry to show completion
+  - **Outcome**: Documentation now lists Files API as ready and notes supported operations
+
+#### :sparkles: What went well
+  - Workflow tools ran smoothly with no errors
+  - Documentation update was straightforward
+
+#### :warning: Pain points
+  - Running tests and coverage for docs-only changes added overhead on local machine
+  - Fetching linter dependencies each run slowed feedback
+
+#### :bulb: Proposed Improvement
+  - Provide cached binaries for dscanner and dfmt to speed up non-code documentation updates

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
 - [ ] [Fine-tunings](https://platform.openai.com/docs/api-reference/fine-tuning) (TODO)
 - [ ] [Graders](https://platform.openai.com/docs/api-reference/graders) (TODO)
 - [ ] [Batch](https://platform.openai.com/docs/api-reference/batch) (TODO)
- - [ ] [Files](https://platform.openai.com/docs/api-reference/files) (WIP)
+ - [x] [Files](https://platform.openai.com/docs/api-reference/files) — upload, list, retrieve, delete, download
 - [ ] [Uploads](https://platform.openai.com/docs/api-reference/uploads) (TODO)
 - [x] [Models](https://platform.openai.com/docs/api-reference/models)
 - [x] [Moderations](https://platform.openai.com/docs/api-reference/moderations)


### PR DESCRIPTION
## Summary
- mark Files API as done in README
- add reflection note about documentation update

## Testing
- `dub run dfmt -- source examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_685343c9871c832c939db613bf22ce1e