### PR TITLE
[docs] complete project API key docs

### DIFF
--- a/.agents/reflections/2025-06-18-2322-update-readme-project-keys.md
+++ b/.agents/reflections/2025-06-18-2322-update-readme-project-keys.md
@@ -1,0 +1,18 @@
+### :book: Reflection for [2025-06-18 23:22]
+  - **Task**: Update README to document project API keys example
+  - **Objective**: Reflect new functionality and show how to use project API keys
+  - **Outcome**: README now marks the feature complete and references a sample
+    project API key usage snippet
+
+#### :sparkles: What went well
+  - README changes were small and straightforward
+  - Automated formatting and linting quickly confirmed no issues
+
+#### :warning: Pain points
+  - Building examples still triggers many deprecation warnings, obscuring real
+    problems
+  - Linting downloads dependencies each run, slowing feedback
+
+#### :bulb: Proposed Improvement
+  - Cache D dependencies in CI and local development to speed up linting
+  - Address library deprecations to clean up build logs

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [x] Projects
   - [ ] Project users (TODO)
   - [ ] Project service accounts (TODO)
-  - [ ] Project API keys (WIP)
+  - [x] Project API keys
   - [ ] Project rate limits (TODO)
   - [x] Audit logs
   - [x] Usage
@@ -300,8 +300,20 @@ auto usage = client.listUsageCompletions(req);
 writeln(usage.data.length);
 ```
 
-Requires an admin API key. See `examples/administration` and
-`examples/administration_invites` for complete examples.
+```d name=admin_project_api_keys
+import std;
+import openai;
+
+auto client = new OpenAIClient();
+auto list = client.listProjectApiKeys("<project id>",
+    listProjectApiKeysRequest(20));
+writeln(list.data.length);
+```
+
+Requires an admin API key. See `examples/administration`,
+`examples/administration_invites`, and
+`examples/administration_project_api_keys` for complete examples.
+
 
 
 ## OpenAIClientConfig


### PR DESCRIPTION
## Summary
- mark project API keys as implemented
- add example snippet for project API keys
- reference new project API key example in README
- record reflection on updating the README

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_685348f25a0c832cba394e89fe2f85f2