### PR TITLE
[administration] add user management models

### DIFF
--- a/.agents/reflections/2025-06-19-0345-add-admin-user-models.md
+++ b/.agents/reflections/2025-06-19-0345-add-admin-user-models.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-19 03:45]
+- **Task**: add user models and tests
+- **Objective**: extend administration module with user management structures and ensure coverage
+- **Outcome**: new structs and tests added successfully
+
+#### :sparkles: What went well
+- mir.serde annotations were straightforward to replicate
+- automated dfmt and linter kept style consistent
+
+#### :warning: Pain points
+- example build script generated many untracked files, requiring manual cleanup
+- viewing long build logs in the container was cumbersome
+
+#### :bulb: Proposed Improvement
+- update build script to place temporary outputs in a clean directory or auto-clean after running to avoid polluting git status

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -281,6 +281,62 @@ InviteRequest inviteRequest(string email, string role)
 }
 
 @serdeIgnoreUnexpectedKeys
+struct User
+{
+    string object;
+    string id;
+    string name;
+    string email;
+    string role;
+    @serdeKeys("added_at") long addedAt;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct UserListResponse
+{
+    string object;
+    User[] data;
+    @serdeKeys("first_id") string firstId;
+    @serdeKeys("last_id") string lastId;
+    @serdeKeys("has_more") bool hasMore;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct UserDeleteResponse
+{
+    string object;
+    string id;
+    bool deleted;
+}
+
+struct UserRoleUpdateRequest
+{
+    string role;
+}
+
+/// Convenience constructor for `UserRoleUpdateRequest`.
+UserRoleUpdateRequest userRoleUpdateRequest(string role)
+{
+    auto req = UserRoleUpdateRequest();
+    req.role = role;
+    return req;
+}
+
+struct ListUsersRequest
+{
+    @serdeOptional @serdeIgnoreDefault uint limit;
+    @serdeOptional @serdeIgnoreDefault string after;
+}
+
+/// Convenience constructor for `ListUsersRequest`.
+ListUsersRequest listUsersRequest(uint limit)
+{
+    auto req = ListUsersRequest();
+    req.limit = limit;
+    return req;
+}
+
+@serdeIgnoreUnexpectedKeys
 struct CertificateDetails
 {
     @serdeKeys("valid_at") long validAt;
@@ -1217,4 +1273,25 @@ unittest
     auto list = deserializeJson!ProjectApiKeyListResponse(example);
     assert(list.data.length == 1);
     assert(list.data[0].id == "key_abc");
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    enum example =
+        `{"object":"list","data":[{"object":"organization.user","id":"user-1","name":"Alice","email":"a@example.com","role":"owner","added_at":1}],"first_id":"user-1","last_id":"user-1","has_more":false}`;
+    auto list = deserializeJson!UserListResponse(example);
+    assert(list.data.length == 1);
+    assert(list.data[0].name == "Alice");
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = listUsersRequest(10);
+    assert(serializeJson(req) == `{"limit":10}`);
+    auto role = userRoleUpdateRequest("admin");
+    assert(serializeJson(role) == `{"role":"admin"}`);
 }


### PR DESCRIPTION
## Summary
- add `User` models and related request/response types
- provide convenience constructors for user requests
- test user model JSON (de)serialization
- document work in new reflection note

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`

------
https://chatgpt.com/codex/tasks/task_e_685385885208832c88022bc99ad701a5