### PR TITLE
[clients] add admin user endpoints

### DIFF
--- a/.agents/reflections/2025-06-19-1211-support-admin-user-endpoints.md
+++ b/.agents/reflections/2025-06-19-1211-support-admin-user-endpoints.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-19 12:11]
+  - **Task**: add admin user endpoints
+  - **Objective**: expand the OpenAI client with functions for managing organization users
+  - **Outcome**: implemented list, retrieve, modify, and delete user API calls with accompanying tests
+
+#### :sparkles: What went well
+  - The existing patterns for other admin functions made it straightforward to implement the new methods
+  - Automated formatting, linting, tests and example builds ensured consistency
+
+#### :warning: Pain points
+  - Running the example build script produced numerous deprecation warnings which cluttered the output
+  - dfmt and dscanner downloads slowed down the feedback loop in the container environment
+
+#### :bulb: Proposed Improvement
+  - Cache dfmt and dscanner binaries within the development container to avoid repeated downloads
+  - Investigate suppressing or addressing deprecation warnings to keep build logs concise


### PR DESCRIPTION
## Summary
- implement admin user operations in `OpenAIClient`
- add tests for query builder
- document development reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`

------
https://chatgpt.com/codex/tasks/task_e_6853fbc42ea8832cbf22eb86d77f43a0