### PR TITLE
[examples] add administration_users sample

### DIFF
--- a/.agents/reflections/2025-06-19-1243-add-administration-users-example.md
+++ b/.agents/reflections/2025-06-19-1243-add-administration-users-example.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-19 12:43]
+  - **Task**: Add administration_users example
+  - **Objective**: Provide a sample program demonstrating listing organization users
+  - **Outcome**: Created new example directory with build files and basic code
+
+#### :sparkles: What went well
+  - Automated formatting and linting tools ran smoothly
+  - Build script automatically compiled the new example
+
+#### :warning: Pain points
+  - Running the linter downloads several packages each time which slows feedback
+  - Build examples script produced many deprecation warnings from dependencies
+
+#### :bulb: Proposed Improvement
+  - Cache dscanner and other tools locally in CI to avoid repeated downloads
+  - Silence third-party deprecation warnings when building examples

--- a/examples/administration_users/.gitignore
+++ b/examples/administration_users/.gitignore
@@ -1,0 +1,16 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/administration_users
+administration_users.so
+administration_users.dylib
+administration_users.dll
+administration_users.a
+administration_users.lib
+administration_users-test-*
+*.exe
+*.pdb
+*.o
+*.obj
+*.lst

--- a/examples/administration_users/dub.sdl
+++ b/examples/administration_users/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_users"
+description "List users example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_users/dub.selections.json
+++ b/examples/administration_users/dub.selections.json
@@ -1,0 +1,11 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/administration_users/source/app.d
+++ b/examples/administration_users/source/app.d
@@ -1,0 +1,10 @@
+import std.stdio;
+
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+    auto list = client.listUsers(listUsersRequest(20));
+    writeln(list.data.length);
+}


### PR DESCRIPTION
## Summary
- add examples/administration_users sample project
- include reflection for the task

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh all administration_users`


------
https://chatgpt.com/codex/tasks/task_e_685404f5eb38832c9ace509442dd8e1e