### PR TITLE
[docs] add administration users example

### DIFF
--- a/.agents/reflections/2025-06-19-1256-admin-users-example.md
+++ b/.agents/reflections/2025-06-19-1256-admin-users-example.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-19 12:56]
+  - **Task**: Document admin users example
+  - **Objective**: Update README with a new administration example and mark users feature complete
+  - **Outcome**: Added snippet, updated example references, and finalized checklist entry
+
+#### :sparkles: What went well
+  - Build and test process succeeded without issues
+  - Automated formatting and linting kept style consistent
+
+#### :warning: Pain points
+  - Example builds generated unwanted artifacts that required cleanup
+  - Long build times for examples slowed iteration
+
+#### :bulb: Proposed Improvement
+  - Provide a make target to clean example build artifacts automatically
+  - …

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
 - [ ] [Administration](https://platform.openai.com/docs/api-reference/administration) (WIP)
   - [x] Admin API Keys
   - [x] Invites
-  - [ ] Users (TODO)
+  - [x] Users
   - [x] Projects
   - [ ] Project users (TODO)
   - [ ] Project service accounts (TODO)
@@ -280,6 +280,15 @@ auto list = client.listInvites(listInvitesRequest(20));
 writeln(list.data.length);
 ```
 
+```d name=admin_users
+import std;
+import openai;
+
+auto client = new OpenAIClient();
+auto list = client.listUsers(listUsersRequest(20));
+writeln(list.data.length);
+```
+
 ```d name=admin_audit_logs
 import std;
 import openai;
@@ -311,8 +320,9 @@ writeln(list.data.length);
 ```
 
 Requires an admin API key. See `examples/administration`,
-`examples/administration_invites`, and
-`examples/administration_project_api_keys` for complete examples.
+`examples/administration_invites`,
+`examples/administration_project_api_keys`, and
+`examples/administration_users` for complete examples.
 
 
 


### PR DESCRIPTION
## Summary
- mark admin users as complete
- show example for listing users
- mention `examples/administration_users`
- add a reflection about documenting the new example

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`

------
https://chatgpt.com/codex/tasks/task_e_685406d3abd4832c986304a4d51968aa