### PR TITLE
[administration] add project users

### DIFF
--- a/.agents/reflections/2025-06-19-1330-administration-project-users-support.md
+++ b/.agents/reflections/2025-06-19-1330-administration-project-users-support.md
@@ -1,0 +1,17 @@
+### :book: Reflection for [2025-06-19 13:30]
+  - **Task**: Add project user models and endpoints
+  - **Objective**: Support administration project user API and example
+  - **Outcome**: Implemented structs, client methods, tests, and example
+
+#### :sparkles: What went well
+  - Leveraged upstream OpenAPI spec to implement accurate models
+  - Automated tests and formatting ensured consistent code quality
+
+#### :warning: Pain points
+  - Running build_examples.sh produced no output initially, making troubleshooting slow on CI-like environments
+  - Downloading and parsing the large OpenAPI spec was time-consuming
+
+#### :bulb: Proposed Improvement
+  - Enhance build_examples.sh with clearer logging when no targets are selected to reduce confusion
+  - Cache the OpenAPI spec locally to avoid repeated large downloads
+

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [x] Invites
   - [x] Users
   - [x] Projects
-  - [ ] Project users (TODO)
+  - [x] Project users
   - [ ] Project service accounts (TODO)
   - [x] Project API keys
   - [ ] Project rate limits (TODO)
@@ -321,7 +321,8 @@ writeln(list.data.length);
 
 Requires an admin API key. See `examples/administration`,
 `examples/administration_invites`,
-`examples/administration_project_api_keys`, and
+`examples/administration_project_api_keys`,
+`examples/administration_project_users`, and
 `examples/administration_users` for complete examples.
 
 

--- a/examples/administration_project_users/dub.sdl
+++ b/examples/administration_project_users/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_project_users"
+description "Administration Project Users API example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_project_users/dub.selections.json
+++ b/examples/administration_project_users/dub.selections.json
@@ -1,0 +1,11 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
+	}
+}

--- a/examples/administration_project_users/source/app.d
+++ b/examples/administration_project_users/source/app.d
@@ -1,0 +1,42 @@
+import std.stdio;
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    // create a project for the user operations
+    auto project = client.createProject(projectCreateRequest("example"));
+
+    // choose a user from the organization
+    auto users = client.listUsers(listUsersRequest(20));
+    if (users.data.length == 0)
+        return;
+    auto userId = users.data[0].id;
+
+    // add the user to the project
+    auto created = client.createProjectUser(project.id,
+        projectUserCreateRequest(userId, "member"));
+    writeln("created: ", created.email);
+
+    // list users in the project
+    auto list = client.listProjectUsers(project.id, listProjectUsersRequest(20));
+    writeln("project users: ", list.data.length);
+
+    // retrieve the project user
+    auto retrieved = client.retrieveProjectUser(project.id, userId);
+    writeln("retrieved role: ", retrieved.role);
+
+    // modify the user's role
+    auto modified = client.modifyProjectUser(project.id, userId,
+        projectUserUpdateRequest("owner"));
+    writeln("modified role: ", modified.role);
+
+    // delete the user from the project
+    auto deleted = client.deleteProjectUser(project.id, userId);
+    writeln("deleted: ", deleted.deleted);
+
+    // archive the project
+    auto archived = client.archiveProject(project.id);
+    writeln("archived: ", archived.status);
+}

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -141,6 +141,63 @@ ProjectUpdateRequest projectUpdateRequest(string name)
 }
 
 @serdeIgnoreUnexpectedKeys
+struct ProjectUser
+{
+    string object;
+    string id;
+    string name;
+    string email;
+    string role;
+    @serdeKeys("added_at") long addedAt;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectUserListResponse
+{
+    string object;
+    ProjectUser[] data;
+    @serdeKeys("first_id") string firstId;
+    @serdeKeys("last_id") string lastId;
+    @serdeKeys("has_more") bool hasMore;
+}
+
+struct ProjectUserCreateRequest
+{
+    @serdeKeys("user_id") string userId;
+    string role;
+}
+
+/// Convenience constructor for `ProjectUserCreateRequest`.
+ProjectUserCreateRequest projectUserCreateRequest(string userId, string role)
+{
+    auto req = ProjectUserCreateRequest();
+    req.userId = userId;
+    req.role = role;
+    return req;
+}
+
+struct ProjectUserUpdateRequest
+{
+    string role;
+}
+
+/// Convenience constructor for `ProjectUserUpdateRequest`.
+ProjectUserUpdateRequest projectUserUpdateRequest(string role)
+{
+    auto req = ProjectUserUpdateRequest();
+    req.role = role;
+    return req;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectUserDeleteResponse
+{
+    string object;
+    string id;
+    bool deleted;
+}
+
+@serdeIgnoreUnexpectedKeys
 struct ProjectApiKey
 {
     string object;
@@ -326,6 +383,20 @@ struct ListUsersRequest
 {
     @serdeOptional @serdeIgnoreDefault uint limit;
     @serdeOptional @serdeIgnoreDefault string after;
+}
+
+struct ListProjectUsersRequest
+{
+    @serdeOptional @serdeIgnoreDefault uint limit;
+    @serdeOptional @serdeIgnoreDefault string after;
+}
+
+/// Convenience constructor for `ListProjectUsersRequest`.
+ListProjectUsersRequest listProjectUsersRequest(uint limit)
+{
+    auto req = ListProjectUsersRequest();
+    req.limit = limit;
+    return req;
 }
 
 /// Convenience constructor for `ListUsersRequest`.
@@ -1294,4 +1365,28 @@ unittest
     assert(serializeJson(req) == `{"limit":10}`);
     auto role = userRoleUpdateRequest("admin");
     assert(serializeJson(role) == `{"role":"admin"}`);
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+    import mir.ser.json : serializeJson;
+
+    enum listExample =
+        `{"object":"list","data":[{"object":"organization.project.user","id":"user_abc","name":"First Last","email":"user@example.com","role":"owner","added_at":1}],"first_id":"user_abc","last_id":"user_abc","has_more":false}`;
+    auto list = deserializeJson!ProjectUserListResponse(listExample);
+    assert(list.data.length == 1);
+    assert(list.data[0].email == "user@example.com");
+
+    enum delExample =
+        `{"object":"organization.project.user.deleted","id":"user_abc","deleted":true}`;
+    auto del = deserializeJson!ProjectUserDeleteResponse(delExample);
+    assert(del.deleted);
+
+    auto lreq = listProjectUsersRequest(5);
+    assert(serializeJson(lreq) == `{"limit":5}`);
+    auto creq = projectUserCreateRequest("user_abc", "member");
+    assert(serializeJson(creq) == `{"user_id":"user_abc","role":"member"}`);
+    auto ureq = projectUserUpdateRequest("owner");
+    assert(serializeJson(ureq) == `{"role":"owner"}`);
 }

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -987,6 +987,86 @@ class OpenAIClient
         return content.deserializeJson!Project();
     }
 
+    /// List users in a project.
+    ProjectUserListResponse listProjectUsers(string projectId, in ListProjectUsersRequest request) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (projectId.length > 0)
+    {
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+
+        string url = buildListProjectUsersUrl(projectId, request);
+
+        auto content = cast(char[]) get!(HTTP, ubyte)(url, http);
+        return content.deserializeJson!ProjectUserListResponse();
+    }
+
+    /// Add a user to a project.
+    ProjectUser createProjectUser(string projectId, in ProjectUserCreateRequest request) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (projectId.length > 0)
+    {
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+        http.addRequestHeader("Content-Type", "application/json");
+
+        auto body = serializeJson(request);
+        auto content = cast(char[]) post!ubyte(buildUrl("/organization/projects/" ~ projectId ~ "/users"), body, http);
+        return content.deserializeJson!ProjectUser();
+    }
+
+    /// Retrieve a project user by ID.
+    ProjectUser retrieveProjectUser(string projectId, string userId) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (projectId.length > 0)
+    in (userId.length > 0)
+    {
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+
+        auto content = cast(char[]) get!(HTTP, ubyte)(
+            buildUrl("/organization/projects/" ~ projectId ~ "/users/" ~ userId), http);
+        return content.deserializeJson!ProjectUser();
+    }
+
+    /// Modify a project user's role.
+    ProjectUser modifyProjectUser(string projectId, string userId, in ProjectUserUpdateRequest request) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (projectId.length > 0)
+    in (userId.length > 0)
+    {
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+        http.addRequestHeader("Content-Type", "application/json");
+
+        auto body = serializeJson(request);
+        auto content = cast(char[]) post!ubyte(buildUrl("/organization/projects/" ~ projectId ~ "/users/" ~ userId), body, http);
+        return content.deserializeJson!ProjectUser();
+    }
+
+    /// Delete a user from a project.
+    ProjectUserDeleteResponse deleteProjectUser(string projectId, string userId) @system
+    in (config.apiKey != null && config.apiKey.length > 0)
+    in (projectId.length > 0)
+    in (userId.length > 0)
+    {
+        auto http = HTTP();
+        setupHttpByConfig(http);
+        http.addRequestHeader("Accept", "application/json; charset=utf-8");
+
+        import std.array : appender;
+
+        auto buf = appender!(char[])();
+        http.onReceive = (ubyte[] data) { buf.put(cast(char[]) data); return data.length; };
+        del(buildUrl("/organization/projects/" ~ projectId ~ "/users/" ~ userId), http);
+        auto content = buf.data;
+        return content.deserializeJson!ProjectUserDeleteResponse();
+    }
+
     /// List API keys for a project.
     ProjectApiKeyListResponse listProjectApiKeys(string projectId, in ListProjectApiKeysRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
@@ -1439,6 +1519,23 @@ class OpenAIClient
         import std.uri : encodeComponent;
 
         string url = buildUrl("/organization/users");
+        string sep = "?";
+        if (request.limit)
+        {
+            url ~= format("%slimit=%s", sep, request.limit);
+            sep = "&";
+        }
+        if (request.after.length)
+            url ~= format("%safter=%s", sep, encodeComponent(request.after));
+        return url;
+    }
+
+    private string buildListProjectUsersUrl(string projectId, in ListProjectUsersRequest request) const @safe
+    {
+        import std.format : format;
+        import std.uri : encodeComponent;
+
+        string url = buildUrl("/organization/projects/" ~ projectId ~ "/users");
         string sep = "?";
         if (request.limit)
         {
@@ -2171,6 +2268,50 @@ unittest
     req.limit = 3;
     req.after = "foo bar";
     auto url = client.buildListUsersUrl(req);
+
+    assert(url.canFind("limit=3"));
+    assert(url.canFind("after=foo%20bar"));
+}
+
+@("buildListProjectUsersUrl")
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    auto cfg = new OpenAIClientConfig;
+    cfg.apiKey = "k";
+    auto client = new OpenAIClient(cfg);
+
+    auto req = ListProjectUsersRequest();
+    auto url = client.buildListProjectUsersUrl("p", req);
+
+    assert(!url.canFind("limit="));
+    assert(!url.canFind("after="));
+
+    req.limit = 2;
+    url = client.buildListProjectUsersUrl("p", req);
+    assert(url.canFind("limit=2"));
+
+    req.limit = 0;
+    req.after = "foo";
+    url = client.buildListProjectUsersUrl("p", req);
+    assert(url.canFind("after=foo"));
+    assert(!url.canFind("limit="));
+}
+
+@("buildListProjectUsersUrl encodes query parameters")
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    auto cfg = new OpenAIClientConfig;
+    cfg.apiKey = "k";
+    auto client = new OpenAIClient(cfg);
+
+    auto req = ListProjectUsersRequest();
+    req.limit = 3;
+    req.after = "foo bar";
+    auto url = client.buildListProjectUsersUrl("p", req);
 
     assert(url.canFind("limit=3"));
     assert(url.canFind("after=foo%20bar"));


### PR DESCRIPTION
## Summary
- implement project user models and request helpers
- add project user API client methods with URL builder
- support serialization tests for project user models
- include example for administration project users
- document the new example in README
- note reflection for project user support

## Testing
- `dub run dfmt -- source examples/administration_project_users`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `scripts/build_examples.sh core administration_project_users`

------
https://chatgpt.com/codex/tasks/task_e_68540f1e55a4832c95487d0a0e045325