### PR TITLE
[administration] add project service account structs

### DIFF
--- a/.agents/reflections/2025-06-19-1409-add-project-service-account-structs.md
+++ b/.agents/reflections/2025-06-19-1409-add-project-service-account-structs.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-19 14:09]
+  - **Task**: implement project service account structs
+  - **Objective**: extend administration module with service account models and tests
+  - **Outcome**: added new structs with serialization annotations, convenience constructors, and unit tests; all checks pass
+
+#### :sparkles: What went well
+  - Accessing the official OpenAPI spec provided accurate field names
+  - Existing patterns for models and tests made implementation straightforward
+
+#### :warning: Pain points
+  - Running dfmt and lint downloads dependencies each time, which slows feedback
+  - Example builds emit many deprecation warnings that obscure important messages
+
+#### :bulb: Proposed Improvement
+  - Cache dfmt and dscanner artifacts between runs in CI and local development to reduce wait time
+  - Silence or address deprecation warnings in example builds for clearer output

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -198,6 +198,82 @@ struct ProjectUserDeleteResponse
 }
 
 @serdeIgnoreUnexpectedKeys
+struct ProjectServiceAccount
+{
+    string object;
+    string id;
+    string name;
+    string role;
+    @serdeKeys("created_at") long createdAt;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectServiceAccountApiKey
+{
+    string object;
+    string value;
+    string name;
+    @serdeKeys("created_at") long createdAt;
+    string id;
+}
+
+struct ProjectServiceAccountCreateRequest
+{
+    string name;
+}
+
+/// Convenience constructor for `ProjectServiceAccountCreateRequest`.
+ProjectServiceAccountCreateRequest projectServiceAccountCreateRequest(string name)
+{
+    auto req = ProjectServiceAccountCreateRequest();
+    req.name = name;
+    return req;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectServiceAccountCreateResponse
+{
+    string object;
+    string id;
+    string name;
+    string role;
+    @serdeKeys("created_at") long createdAt;
+    @serdeKeys("api_key") ProjectServiceAccountApiKey apiKey;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectServiceAccountDeleteResponse
+{
+    string object;
+    string id;
+    bool deleted;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectServiceAccountListResponse
+{
+    string object;
+    ProjectServiceAccount[] data;
+    @serdeKeys("first_id") string firstId;
+    @serdeKeys("last_id") string lastId;
+    @serdeKeys("has_more") bool hasMore;
+}
+
+struct ListProjectServiceAccountsRequest
+{
+    @serdeOptional @serdeIgnoreDefault uint limit;
+    @serdeOptional @serdeIgnoreDefault string after;
+}
+
+/// Convenience constructor for `ListProjectServiceAccountsRequest`.
+ListProjectServiceAccountsRequest listProjectServiceAccountsRequest(uint limit)
+{
+    auto req = ListProjectServiceAccountsRequest();
+    req.limit = limit;
+    return req;
+}
+
+@serdeIgnoreUnexpectedKeys
 struct ProjectApiKey
 {
     string object;
@@ -1389,4 +1465,31 @@ unittest
     assert(serializeJson(creq) == `{"user_id":"user_abc","role":"member"}`);
     auto ureq = projectUserUpdateRequest("owner");
     assert(serializeJson(ureq) == `{"role":"owner"}`);
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+    import mir.ser.json : serializeJson;
+
+    enum listExample =
+        `{"object":"list","data":[{"object":"organization.project.service_account","id":"svc_acct_abc","name":"Service Account","role":"owner","created_at":1711471533}],"first_id":"svc_acct_abc","last_id":"svc_acct_xyz","has_more":false}`;
+    auto list = deserializeJson!ProjectServiceAccountListResponse(listExample);
+    assert(list.data.length == 1);
+    assert(list.data[0].name == "Service Account");
+
+    enum createExample =
+        `{"object":"organization.project.service_account","id":"svc_acct_abc","name":"Production App","role":"member","created_at":1711471533,"api_key":{"object":"organization.project.service_account.api_key","value":"sk-abcdefghijklmnop123","name":"Secret Key","created_at":1711471533,"id":"key_abc"}}`;
+    auto create = deserializeJson!ProjectServiceAccountCreateResponse(createExample);
+    assert(create.apiKey.id == "key_abc");
+
+    enum delExample =
+        `{"object":"organization.project.service_account.deleted","id":"svc_acct_abc","deleted":true}`;
+    auto del = deserializeJson!ProjectServiceAccountDeleteResponse(delExample);
+    assert(del.deleted);
+
+    auto lreq = listProjectServiceAccountsRequest(5);
+    assert(serializeJson(lreq) == `{"limit":5}`);
+    auto creq = projectServiceAccountCreateRequest("My SA");
+    assert(serializeJson(creq) == `{"name":"My SA"}`);
 }


### PR DESCRIPTION
## Summary
- define models for project service accounts and related requests
- implement helpers for creating/listing service accounts
- test (de)serialization of the new structures
- document reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test -q`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core administration`

------
https://chatgpt.com/codex/tasks/task_e_685418a43340832c81d8afe2df8de743