### PR TITLE
[docs] mark project service accounts WIP

### DIFF
--- a/.agents/reflections/2025-06-19-1412-project-service-accounts-wip.md
+++ b/.agents/reflections/2025-06-19-1412-project-service-accounts-wip.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-19 14:12]
+  - **Task**: Update README status for project service accounts
+  - **Objective**: Reflect current progress accurately in checklist
+  - **Outcome**: README updated and repository checks passed
+
+#### :sparkles: What went well
+  - Task was small and straightforward
+  - Automated checks ensured no formatting or test regressions
+
+#### :warning: Pain points
+  - Building example binaries produced many temporary artifacts
+  - Cleaning those artifacts took extra time before commit
+
+#### :bulb: Proposed Improvement
+  - Adjust example build script to place artifacts in a dedicated ignored directory
+  - This would avoid cluttering version control with build outputs

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [x] Users
   - [x] Projects
   - [x] Project users
-  - [ ] Project service accounts (TODO)
+  - [ ] Project service accounts (WIP)
   - [x] Project API keys
   - [ ] Project rate limits (TODO)
   - [x] Audit logs


### PR DESCRIPTION
## Summary
- update README project service account status
- add reflection about this documentation fix

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6854189e7618832c966c564502ef3ff7