### PR TITLE
[clients] add project service account endpoints

### DIFF
--- a/.agents/reflections/2025-06-19-1421-project-service-account-methods.md
+++ b/.agents/reflections/2025-06-19-1421-project-service-account-methods.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-19 14:21]
+  - **Task**: implement project service account methods
+  - **Objective**: expose API endpoints for service account management
+  - **Outcome**: methods and tests added, all checks passed
+
+#### :sparkles: What went well
+  - Reused existing patterns for project user APIs to implement service account endpoints quickly
+  - Unit tests verify URL builder behavior just like other endpoints
+
+#### :warning: Pain points
+  - Rebuilding example binaries still generates many warnings and temporary files, slowing down development on this container
+  - Coverage runs are lengthy due to compiling dependencies
+
+#### :bulb: Proposed Improvement
+  - Adjust build_examples.sh to clean generated artifacts automatically to reduce manual cleanup time


### PR DESCRIPTION
## Summary
- implement project service account API methods in OpenAIClient
- support building list project service account URLs
- add unit tests for URL builder
- document reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_68541b8cc9bc832c90b4c0a0f764f234