### PR TITLE
[examples] add project service accounts sample

### DIFF
--- a/.agents/reflections/2025-06-19-2233-project-service-accounts-example.md
+++ b/.agents/reflections/2025-06-19-2233-project-service-accounts-example.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-19 22:33]
+  - **Task**: add project service accounts example and update docs
+  - **Objective**: demonstrate service account operations in a new sample and document them
+  - **Outcome**: example added, README updated, all checks succeeded
+
+#### :sparkles: What went well
+  - Reused existing project API key sample structure for quick development
+  - Automated formatting and linting ensured consistent style
+
+#### :warning: Pain points
+  - `dub` modified `dub.selections.json` files during example builds, requiring manual resets
+  - Example build script only builds minimal projects, so new samples aren't verified automatically
+
+#### :bulb: Proposed Improvement
+  - Adjust build script to optionally include underscore directories when groups are specified
+  - This would compile new examples without modifying selection files unexpectedly

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [x] Users
   - [x] Projects
   - [x] Project users
-  - [ ] Project service accounts (WIP)
+  - [x] Project service accounts
   - [x] Project API keys
   - [ ] Project rate limits (TODO)
   - [x] Audit logs
@@ -318,10 +318,20 @@ auto list = client.listProjectApiKeys("<project id>",
     listProjectApiKeysRequest(20));
 writeln(list.data.length);
 ```
+```d name=admin_project_service_accounts
+import std;
+import openai;
+
+auto client = new OpenAIClient();
+auto list = client.listProjectServiceAccounts("<project id>",
+    listProjectServiceAccountsRequest(20));
+writeln(list.data.length);
+```
 
 Requires an admin API key. See `examples/administration`,
 `examples/administration_invites`,
 `examples/administration_project_api_keys`,
+`examples/administration_project_service_accounts`,
 `examples/administration_project_users`, and
 `examples/administration_users` for complete examples.
 

--- a/examples/administration_project_service_accounts/dub.sdl
+++ b/examples/administration_project_service_accounts/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_project_service_accounts"
+description "Project service account management example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_project_service_accounts/dub.selections.json
+++ b/examples/administration_project_service_accounts/dub.selections.json
@@ -1,0 +1,10 @@
+{
+        "fileVersion": 1,
+        "versions": {
+                "mir-algorithm": "3.22.3",
+                "mir-core": "1.7.1",
+                "mir-cpuid": "1.2.11",
+                "mir-ion": "2.3.4",
+                "openai-d": {"path":"../.."}
+        }
+}

--- a/examples/administration_project_service_accounts/source/app.d
+++ b/examples/administration_project_service_accounts/source/app.d
@@ -1,0 +1,32 @@
+import std.stdio;
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    // create a project
+    auto project = client.createProject(projectCreateRequest("example"));
+
+    // create a service account for the project
+    auto created = client.createProjectServiceAccount(project.id,
+        projectServiceAccountCreateRequest("Example Service Account"));
+    writeln("created: ", created.id);
+
+    // list service accounts
+    auto list = client.listProjectServiceAccounts(project.id,
+        listProjectServiceAccountsRequest(20));
+    writeln("service accounts: ", list.data.length);
+
+    // retrieve the newly created account
+    auto retrieved = client.retrieveProjectServiceAccount(project.id, created.id);
+    writeln("retrieved: ", retrieved.name);
+
+    // delete the service account
+    auto deleted = client.deleteProjectServiceAccount(project.id, created.id);
+    writeln("deleted: ", deleted.deleted);
+
+    // archive the project
+    auto archived = client.archiveProject(project.id);
+    writeln("archived: ", archived.status);
+}


### PR DESCRIPTION
## Summary
- add administration project service accounts sample
- document example usage in README
- update features list to mark service accounts complete
- add reflection about adding the new example

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core administration`


------
https://chatgpt.com/codex/tasks/task_e_68548e9d4414832c93bed34077f4c8d2