### PR TITLE
[administration] add project rate limits support

### DIFF
--- a/.agents/reflections/2025-06-19-2313-project-rate-limits.md
+++ b/.agents/reflections/2025-06-19-2313-project-rate-limits.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-19 23:13]
+  - **Task**: implement project rate limits
+  - **Objective**: extend admin client with project rate limit endpoints and example
+  - **Outcome**: implemented data types, client methods, example program, docs updated, and checks passed
+
+#### :sparkles: What went well
+  - Adding new structs followed clear patterns from existing code
+  - Formatter and linter quickly highlighted minor style issues
+
+#### :warning: Pain points
+  - Locating official API details for rate limits required guessing field names due to missing openapi specs
+  - Applying README patches was tricky because of exact line matching and quoting
+
+#### :bulb: Proposed Improvement
+  - Provide a helper script that inserts example snippets into README to reduce manual patching errors
+  - Host an offline copy of the OpenAI OpenAPI spec within the repo so field details are readily available

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This library provides unofficial D clients for [OpenAI API](https://platform.ope
   - [x] Project users
   - [x] Project service accounts
   - [x] Project API keys
-  - [ ] Project rate limits (TODO)
+  - [x] Project rate limits
   - [x] Audit logs
   - [x] Usage
   - [x] Certificates
@@ -327,11 +327,21 @@ auto list = client.listProjectServiceAccounts("<project id>",
     listProjectServiceAccountsRequest(20));
 writeln(list.data.length);
 ```
+```d name=admin_project_rate_limits
+import std;
+import openai;
+
+auto client = new OpenAIClient();
+auto list = client.listProjectRateLimits("<project id>",
+    listProjectRateLimitsRequest(20));
+writeln(list.data.length);
+```
 
 Requires an admin API key. See `examples/administration`,
 `examples/administration_invites`,
 `examples/administration_project_api_keys`,
 `examples/administration_project_service_accounts`,
+`examples/administration_project_rate_limits`,
 `examples/administration_project_users`, and
 `examples/administration_users` for complete examples.
 

--- a/examples/administration_project_rate_limits/dub.sdl
+++ b/examples/administration_project_rate_limits/dub.sdl
@@ -1,0 +1,6 @@
+name "administration_project_rate_limits"
+description "Project rate limit management example"
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/administration_project_rate_limits/dub.selections.json
+++ b/examples/administration_project_rate_limits/dub.selections.json
@@ -1,0 +1,10 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.3",
+		"mir-core": "1.7.1",
+		"mir-cpuid": "1.2.11",
+                "mir-ion": "2.3.4",
+                "openai-d": {"path":"../.."}
+	}
+}

--- a/examples/administration_project_rate_limits/source/app.d
+++ b/examples/administration_project_rate_limits/source/app.d
@@ -1,0 +1,36 @@
+import std.stdio;
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    // create a project for the rate limit
+    auto project = client.createProject(projectCreateRequest("example"));
+
+    // create a project rate limit
+    auto limit = client.createProjectRateLimit(project.id,
+        createProjectRateLimitRequest(60, 1_000, 5, 100, 1_000, 5_000));
+
+    // list project rate limits
+    auto list = client.listProjectRateLimits(project.id,
+        listProjectRateLimitsRequest(20));
+    writeln("limits: ", list.data.length);
+
+    // retrieve the created rate limit
+    auto retrieved = client.retrieveProjectRateLimit(limit.id);
+    writeln("retrieved: ", retrieved.id);
+
+    // modify the rate limit
+    auto modified = client.modifyProjectRateLimit(limit.id,
+        updateProjectRateLimitRequest(120, 2_000, 10, 200, 2_000, 10_000));
+    writeln("modified: ", modified.maxRequestsPer1Minute);
+
+    // delete the rate limit
+    auto deleted = client.deleteProjectRateLimit(limit.id);
+    writeln("deleted: ", deleted.deleted);
+
+    // archive the project
+    auto archived = client.archiveProject(project.id);
+    writeln("archived: ", archived.status);
+}

--- a/source/openai/administration.d
+++ b/source/openai/administration.d
@@ -345,6 +345,115 @@ struct DeleteProjectApiKeyResponse
 }
 
 @serdeIgnoreUnexpectedKeys
+struct ProjectRateLimit
+{
+    string object;
+    string id;
+    @serdeKeys("max_requests_per_1_minute") long maxRequestsPer1Minute;
+    @serdeKeys("max_tokens_per_1_minute") long maxTokensPer1Minute;
+    @serdeKeys("max_images_per_1_minute") long maxImagesPer1Minute;
+    @serdeKeys("max_audio_megabytes_per_1_minute") long maxAudioMegabytesPer1Minute;
+    @serdeKeys("max_requests_per_1_day") long maxRequestsPer1Day;
+    @serdeKeys("batch_1_day_max_input_tokens") long batch1DayMaxInputTokens;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct ProjectRateLimitListResponse
+{
+    string object;
+    ProjectRateLimit[] data;
+    @serdeKeys("first_id") string firstId;
+    @serdeKeys("last_id") string lastId;
+    @serdeKeys("has_more") bool hasMore;
+}
+
+struct ListProjectRateLimitsRequest
+{
+    @serdeOptional @serdeIgnoreDefault uint limit;
+    @serdeOptional @serdeIgnoreDefault string after;
+}
+
+/// Convenience constructor for `ListProjectRateLimitsRequest`.
+ListProjectRateLimitsRequest listProjectRateLimitsRequest(uint limit)
+{
+    auto req = ListProjectRateLimitsRequest();
+    req.limit = limit;
+    return req;
+}
+
+struct CreateProjectRateLimitRequest
+{
+    @serdeKeys("max_requests_per_1_minute") long maxRequestsPer1Minute;
+    @serdeKeys("max_tokens_per_1_minute") long maxTokensPer1Minute;
+    @serdeKeys("max_images_per_1_minute") long maxImagesPer1Minute;
+    @serdeKeys("max_audio_megabytes_per_1_minute") long maxAudioMegabytesPer1Minute;
+    @serdeKeys("max_requests_per_1_day") long maxRequestsPer1Day;
+    @serdeKeys("batch_1_day_max_input_tokens") long batch1DayMaxInputTokens;
+}
+
+/// Convenience constructor for `CreateProjectRateLimitRequest`.
+CreateProjectRateLimitRequest createProjectRateLimitRequest(
+    long maxRequestsPer1Minute,
+    long maxTokensPer1Minute,
+    long maxImagesPer1Minute,
+    long maxAudioMegabytesPer1Minute,
+    long maxRequestsPer1Day,
+    long batch1DayMaxInputTokens)
+{
+    auto req = CreateProjectRateLimitRequest();
+    req.maxRequestsPer1Minute = maxRequestsPer1Minute;
+    req.maxTokensPer1Minute = maxTokensPer1Minute;
+    req.maxImagesPer1Minute = maxImagesPer1Minute;
+    req.maxAudioMegabytesPer1Minute = maxAudioMegabytesPer1Minute;
+    req.maxRequestsPer1Day = maxRequestsPer1Day;
+    req.batch1DayMaxInputTokens = batch1DayMaxInputTokens;
+    return req;
+}
+
+struct UpdateProjectRateLimitRequest
+{
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("max_requests_per_1_minute") long maxRequestsPer1Minute;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("max_tokens_per_1_minute") long maxTokensPer1Minute;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("max_images_per_1_minute") long maxImagesPer1Minute;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("max_audio_megabytes_per_1_minute") long maxAudioMegabytesPer1Minute;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("max_requests_per_1_day") long maxRequestsPer1Day;
+    @serdeOptional @serdeIgnoreDefault
+    @serdeKeys("batch_1_day_max_input_tokens") long batch1DayMaxInputTokens;
+}
+
+/// Convenience constructor for `UpdateProjectRateLimitRequest`.
+UpdateProjectRateLimitRequest updateProjectRateLimitRequest(
+    long maxRequestsPer1Minute,
+    long maxTokensPer1Minute,
+    long maxImagesPer1Minute,
+    long maxAudioMegabytesPer1Minute,
+    long maxRequestsPer1Day,
+    long batch1DayMaxInputTokens)
+{
+    auto req = UpdateProjectRateLimitRequest();
+    req.maxRequestsPer1Minute = maxRequestsPer1Minute;
+    req.maxTokensPer1Minute = maxTokensPer1Minute;
+    req.maxImagesPer1Minute = maxImagesPer1Minute;
+    req.maxAudioMegabytesPer1Minute = maxAudioMegabytesPer1Minute;
+    req.maxRequestsPer1Day = maxRequestsPer1Day;
+    req.batch1DayMaxInputTokens = batch1DayMaxInputTokens;
+    return req;
+}
+
+@serdeIgnoreUnexpectedKeys
+struct DeleteProjectRateLimitResponse
+{
+    string object;
+    string id;
+    bool deleted;
+}
+
+@serdeIgnoreUnexpectedKeys
 struct InviteProject
 {
     string id;
@@ -1492,4 +1601,30 @@ unittest
     assert(serializeJson(lreq) == `{"limit":5}`);
     auto creq = projectServiceAccountCreateRequest("My SA");
     assert(serializeJson(creq) == `{"name":"My SA"}`);
+}
+
+unittest
+{
+    import mir.deser.json : deserializeJson;
+    import mir.ser.json : serializeJson;
+
+    enum listExample =
+        `{"object":"list","data":[{"object":"organization.project.rate_limit","id":"rl_abc","max_requests_per_1_minute":10,"max_tokens_per_1_minute":100,"max_images_per_1_minute":5,"max_audio_megabytes_per_1_minute":20,"max_requests_per_1_day":50,"batch_1_day_max_input_tokens":1000}],"first_id":"rl_abc","last_id":"rl_abc","has_more":false}`;
+    auto list = deserializeJson!ProjectRateLimitListResponse(listExample);
+    assert(list.data.length == 1);
+    assert(list.data[0].id == "rl_abc");
+
+    enum delExample =
+        `{"object":"organization.project.rate_limit.deleted","id":"rl_abc","deleted":true}`;
+    auto del = deserializeJson!DeleteProjectRateLimitResponse(delExample);
+    assert(del.deleted);
+
+    auto lreq = listProjectRateLimitsRequest(5);
+    assert(serializeJson(lreq) == `{"limit":5}`);
+
+    auto creq = createProjectRateLimitRequest(1, 2, 3, 4, 5, 6);
+    assert(serializeJson(creq) == `{"max_requests_per_1_minute":1,"max_tokens_per_1_minute":2,"max_images_per_1_minute":3,"max_audio_megabytes_per_1_minute":4,"max_requests_per_1_day":5,"batch_1_day_max_input_tokens":6}`);
+
+    auto ureq = updateProjectRateLimitRequest(1, 2, 3, 4, 5, 6);
+    assert(serializeJson(ureq) == `{"max_requests_per_1_minute":1,"max_tokens_per_1_minute":2,"max_images_per_1_minute":3,"max_audio_megabytes_per_1_minute":4,"max_requests_per_1_day":5,"batch_1_day_max_input_tokens":6}`);
 }


### PR DESCRIPTION
## Summary
- implement `ProjectRateLimit` data structures and helper constructors
- add client methods for project rate limit endpoints
- introduce `buildListProjectRateLimitsUrl` with tests
- provide new example `administration_project_rate_limits`
- document project rate limits in README and mark feature complete
- add reflection for project rate limit work

## Testing
- `dub run dfmt -- source examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_68549741d1fc832c864382fe20dd2063