### PR TITLE
[administration] add enums for project user roles

### DIFF
--- a/.agents/reflections/2025-06-20-0543-add-user-role-invite-status-enums.md
+++ b/.agents/reflections/2025-06-20-0543-add-user-role-invite-status-enums.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 05:43]
+  - **Task**: add user role and invite status enums
+  - **Objective**: implement typed enums and update models and tests
+  - **Outcome**: enums introduced with passing tests and example builds
+
+#### :sparkles: What went well
+  - Automated formatting and linting caught issues early
+  - Accessing the upstream OpenAPI spec provided needed details
+
+#### :warning: Pain points
+  - `build_examples.sh` warnings clutter logs during builds
+  - Downloading dscanner each run still slows linting
+
+#### :bulb: Proposed Improvement
+  - Cache common tooling like dscanner between runs to speed up checks

--- a/examples/administration_project_users/source/app.d
+++ b/examples/administration_project_users/source/app.d
@@ -16,7 +16,7 @@ void main()
 
     // add the user to the project
     auto created = client.createProjectUser(project.id,
-        projectUserCreateRequest(userId, "member"));
+        projectUserCreateRequest(userId, ProjectUserRole.Member));
     writeln("created: ", created.email);
 
     // list users in the project
@@ -29,7 +29,7 @@ void main()
 
     // modify the user's role
     auto modified = client.modifyProjectUser(project.id, userId,
-        projectUserUpdateRequest("owner"));
+        projectUserUpdateRequest(ProjectUserRole.Owner));
     writeln("modified role: ", modified.role);
 
     // delete the user from the project

--- a/source/openai/administration/invites.d
+++ b/source/openai/administration/invites.d
@@ -8,6 +8,13 @@ import mir.algebraic;
 
 @safe:
 
+@serdeEnumProxy!string enum InviteStatus : string
+{
+    Accepted = "accepted",
+    Expired = "expired",
+    Pending = "pending",
+}
+
 struct InviteProject
 {
     string id;
@@ -21,7 +28,7 @@ struct Invite
     string id;
     string email;
     string role;
-    string status;
+    InviteStatus status;
     @serdeKeys("invited_at") long invitedAt;
     @serdeKeys("expires_at") long expiresAt;
     @serdeOptional @serdeKeys("accepted_at") long acceptedAt;

--- a/source/openai/administration/users.d
+++ b/source/openai/administration/users.d
@@ -8,6 +8,12 @@ import mir.algebraic;
 
 @safe:
 
+@serdeEnumProxy!string enum ProjectUserRole : string
+{
+    Owner = "owner",
+    Member = "member",
+}
+
 @serdeIgnoreUnexpectedKeys
 struct ProjectUser
 {
@@ -15,7 +21,7 @@ struct ProjectUser
     string id;
     string name;
     string email;
-    string role;
+    ProjectUserRole role;
     @serdeKeys("added_at") long addedAt;
 }
 
@@ -32,11 +38,11 @@ struct ProjectUserListResponse
 struct ProjectUserCreateRequest
 {
     @serdeKeys("user_id") string userId;
-    string role;
+    ProjectUserRole role;
 }
 
 /// Convenience constructor for `ProjectUserCreateRequest`.
-ProjectUserCreateRequest projectUserCreateRequest(string userId, string role)
+ProjectUserCreateRequest projectUserCreateRequest(string userId, ProjectUserRole role)
 {
     auto req = ProjectUserCreateRequest();
     req.userId = userId;
@@ -46,11 +52,11 @@ ProjectUserCreateRequest projectUserCreateRequest(string userId, string role)
 
 struct ProjectUserUpdateRequest
 {
-    string role;
+    ProjectUserRole role;
 }
 
 /// Convenience constructor for `ProjectUserUpdateRequest`.
-ProjectUserUpdateRequest projectUserUpdateRequest(string role)
+ProjectUserUpdateRequest projectUserUpdateRequest(ProjectUserRole role)
 {
     auto req = ProjectUserUpdateRequest();
     req.role = role;
@@ -96,11 +102,11 @@ struct UserDeleteResponse
 
 struct UserRoleUpdateRequest
 {
-    string role;
+    ProjectUserRole role;
 }
 
 /// Convenience constructor for `UserRoleUpdateRequest`.
-UserRoleUpdateRequest userRoleUpdateRequest(string role)
+UserRoleUpdateRequest userRoleUpdateRequest(ProjectUserRole role)
 {
     auto req = UserRoleUpdateRequest();
     req.role = role;
@@ -152,8 +158,8 @@ unittest
 
     auto req = listUsersRequest(10);
     assert(serializeJson(req) == `{"limit":10}`);
-    auto role = userRoleUpdateRequest("admin");
-    assert(serializeJson(role) == `{"role":"admin"}`);
+    auto role = userRoleUpdateRequest(ProjectUserRole.Owner);
+    assert(serializeJson(role) == `{"role":"owner"}`);
 }
 
 unittest
@@ -174,8 +180,8 @@ unittest
 
     auto lreq = listProjectUsersRequest(5);
     assert(serializeJson(lreq) == `{"limit":5}`);
-    auto creq = projectUserCreateRequest("user_abc", "member");
+    auto creq = projectUserCreateRequest("user_abc", ProjectUserRole.Member);
     assert(serializeJson(creq) == `{"user_id":"user_abc","role":"member"}`);
-    auto ureq = projectUserUpdateRequest("owner");
+    auto ureq = projectUserUpdateRequest(ProjectUserRole.Owner);
     assert(serializeJson(ureq) == `{"role":"owner"}`);
 }


### PR DESCRIPTION
## Summary
- model ProjectUserRole and InviteStatus as enums
- use enums in project user and invite structs
- update convenience constructors, tests and examples
- document reflection

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh all administration_invites administration_project_users`

------
https://chatgpt.com/codex/tasks/task_e_6854f2a2864c832cb56176d8b8b4f045