### PR TITLE
[ci] use dub selections file for cache

### DIFF
--- a/.agents/reflections/2025-06-20-0849-ci-cache-use-selections-file.md
+++ b/.agents/reflections/2025-06-20-0849-ci-cache-use-selections-file.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-20 08:49]
+  - **Task**: add dub selections file and update cache hash
+  - **Objective**: ensure CI caching uses locked dependencies
+  - **Outcome**: implemented successfully with tests passing
+
+#### :sparkles: What went well
+  - build steps completed without issues
+  - CI workflow update straightforward
+
+#### :warning: Pain points
+  - example builds modified tracked selections files requiring cleanup
+  - building many examples slowed iteration
+
+#### :bulb: Proposed Improvement
+  - add script to clean build artifacts automatically after example builds
+  - 

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.dub/packages
-          key: dub-${{ runner.os }}-${{ matrix.dlang }}-${{ hashFiles('dub.json') }}
+          key: dub-${{ runner.os }}-${{ matrix.dlang }}-${{ hashFiles('dub.selections.json') }}
           restore-keys: dub-${{ runner.os }}-${{ matrix.dlang }}-
       - name: Check formatting
         run: |
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.APPDATA }}\dub\packages
-          key: dub-${{ runner.os }}-${{ matrix.dlang }}-${{ hashFiles('dub.json') }}
+          key: dub-${{ runner.os }}-${{ matrix.dlang }}-${{ hashFiles('dub.selections.json') }}
           restore-keys: dub-${{ runner.os }}-${{ matrix.dlang }}-
       - name: Check formatting
         shell: pwsh

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,10 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"silly": "1.1.1"
+	}
+}


### PR DESCRIPTION
## Summary
- add `dub.selections.json`
- cache Dub packages using the selections file
- document work in a reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test --compiler=$DC --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_68551f3aa148832cb49878ed678c7da4