### PR TITLE
[helpers] move query params builder

### DIFF
--- a/.agents/reflections/2025-06-20-1120-query-params-builder.md
+++ b/.agents/reflections/2025-06-20-1120-query-params-builder.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-20 11:20]
+  - **Task**: Implement QueryParamsBuilder and refactor helper functions
+  - **Objective**: Reduce repetitive query string code
+  - **Outcome**: Added new helper module and simplified existing URL builders
+
+#### :sparkles: What went well
+  - The existing tests provided good coverage and ensured refactoring correctness
+  - The build scripts offered a quick way to verify example compilation
+
+#### :warning: Pain points
+  - The build_examples script modified `dub.selections.json` files which required cleanup
+  - Waiting for package dependencies during lint and example builds was time consuming in the container environment
+
+#### :bulb: Proposed Improvement
+  - Add a clean step to `build_examples.sh` to avoid leaving build artifacts in the repository
+  - Cache common dependencies to speed up CI and local workflows

--- a/.agents/reflections/2025-06-20-1133-query-params-fixes.md
+++ b/.agents/reflections/2025-06-20-1133-query-params-fixes.md
@@ -1,0 +1,17 @@
+### :book: Reflection for [2025-06-20 11:33]
+  - **Task**: Apply review feedback on QueryParamsBuilder
+  - **Objective**: Address comments by relocating the helper and simplifying compile-time checks
+  - **Outcome**: Moved QueryParamsBuilder into `openai.clients.helpers` and tightened the static assert expression
+
+#### :sparkles: What went well
+  - Running the formatter and linter ensured consistent code style
+  - Example builds verified no regressions after refactoring
+
+#### :warning: Pain points
+  - Build artifacts from example compilation required manual cleanup
+  - Waiting for dependency downloads slowed down the lint step
+
+#### :bulb: Proposed Improvement
+  - Integrate a cleanup step in `build_examples.sh` to remove temporary outputs automatically
+  - Cache linter dependencies in CI to speed up checks
+

--- a/source/openai/clients/helpers.d
+++ b/source/openai/clients/helpers.d
@@ -1,5 +1,77 @@
 module openai.clients.helpers;
 
+/**
+    Helper struct for building query strings with optional parameters.
+*/
+@safe:
+
+struct QueryParamsBuilder
+{
+    import std.format : format;
+    import std.algorithm : map, joiner;
+    import std.array : array;
+    import std.conv : to;
+    import std.uri : encodeComponent;
+    import std.traits : isIntegral;
+
+    private string _url;
+    private string _sep = "?";
+
+    this(string base)
+    {
+        _url = base;
+    }
+
+    /// Return the final URL with encoded query parameters.
+    string finish() const
+    {
+        return _url;
+    }
+
+    /// Add a string parameter when not empty.
+    void add(string key, string value)
+    {
+        if (value.length)
+        {
+            _url ~= format("%s%s=%s", _sep, key, encodeComponent(value));
+            _sep = "&";
+        }
+    }
+
+    /// Add a boolean flag parameter when true.
+    void add(string key, bool value)
+    {
+        if (value)
+        {
+            _url ~= format("%s%s=true", _sep, key);
+            _sep = "&";
+        }
+    }
+
+    /// Add an integral parameter when non-zero.
+    void add(T)(string key, T value) if (isIntegral!T && !is(T == bool))
+    {
+        if (value)
+        {
+            _url ~= format("%s%s=%s", _sep, key, value);
+            _sep = "&";
+        }
+    }
+
+    /// Add a list of values when not empty. Each element is encoded.
+    void add(T)(string key, T[] values)
+    {
+        static assert(is(typeof(encodeComponent(to!string(values[0])))),
+            "value type unsupported");
+        if (values !is null && values.length)
+        {
+            _url ~= format("%s%s=%s", _sep, key,
+                values.map!(v => encodeComponent(to!string(v))).joiner(",").array);
+            _sep = "&";
+        }
+    }
+}
+
 mixin template ClientHelpers()
 {
     import std.net.curl;
@@ -14,190 +86,90 @@ mixin template ClientHelpers()
 
     private string buildListAuditLogsUrl(in ListAuditLogsRequest request) const @safe
     {
-        import std.format : format;
-        import std.algorithm : map;
-        import std.uri : encodeComponent;
 
-        string url = buildUrl("/organization/audit_logs");
-        string sep = "?";
-        if (request.projectIds !is null && request.projectIds.length)
-            url ~= format("%sproject_ids=%s", sep,
-                request.projectIds.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.eventTypes !is null && request.eventTypes.length)
-            url ~= format("%sevent_types=%s", sep,
-                request.eventTypes.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.actorIds !is null && request.actorIds.length)
-            url ~= format("%sactor_ids=%s", sep,
-                request.actorIds.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.actorEmails !is null && request.actorEmails.length)
-            url ~= format("%sactor_emails=%s", sep,
-                request.actorEmails.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.resourceIds !is null && request.resourceIds.length)
-            url ~= format("%sresource_ids=%s", sep,
-                request.resourceIds.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.effectiveAt.gt)
-            url ~= format("%seffective_at[gt]=%s", sep, request.effectiveAt.gt), sep = "&";
-        if (request.effectiveAt.gte)
-            url ~= format("%seffective_at[gte]=%s", sep, request.effectiveAt.gte), sep = "&";
-        if (request.effectiveAt.lt)
-            url ~= format("%seffective_at[lt]=%s", sep, request.effectiveAt.lt), sep = "&";
-        if (request.effectiveAt.lte)
-            url ~= format("%seffective_at[lte]=%s", sep, request.effectiveAt.lte), sep = "&";
-        if (request.limit)
-            url ~= format("%slimit=%s", sep, request.limit), sep = "&";
-        if (request.after.length)
-            url ~= format("%safter=%s", sep, encodeComponent(request.after)), sep = "&";
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/audit_logs"));
+        b.add("project_ids", request.projectIds);
+        b.add("event_types", request.eventTypes);
+        b.add("actor_ids", request.actorIds);
+        b.add("actor_emails", request.actorEmails);
+        b.add("resource_ids", request.resourceIds);
+        b.add("effective_at[gt]", request.effectiveAt.gt);
+        b.add("effective_at[gte]", request.effectiveAt.gte);
+        b.add("effective_at[lt]", request.effectiveAt.lt);
+        b.add("effective_at[lte]", request.effectiveAt.lte);
+        b.add("limit", request.limit);
+        b.add("after", request.after);
+        return b.finish();
     }
 
     private string buildListUsageUrl(string type, in ListUsageRequest request) const @safe
     {
-        import std.format : format;
-        import std.algorithm : map;
-        import std.uri : encodeComponent;
-
-        string url = buildUrl("/organization/usage/" ~ type);
-        string sep = "?";
-        url ~= format("%sstart_time=%s", sep, request.startTime);
-        sep = "&";
-        if (request.endTime)
-            url ~= format("%send_time=%s", sep, request.endTime), sep = "&";
-        if (request.bucketWidth.length)
-            url ~= format("%sbucket_width=%s", sep, encodeComponent(request.bucketWidth)), sep = "&";
-        if (request.projectIds !is null && request.projectIds.length)
-            url ~= format("%sproject_ids=%s", sep,
-                request.projectIds.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.userIds !is null && request.userIds.length)
-            url ~= format("%suser_ids=%s", sep,
-                request.userIds.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.apiKeyIds !is null && request.apiKeyIds.length)
-            url ~= format("%sapi_key_ids=%s", sep,
-                request.apiKeyIds.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.models !is null && request.models.length)
-            url ~= format("%smodels=%s", sep,
-                request.models.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.groupBy !is null && request.groupBy.length)
-            url ~= format("%sgroup_by=%s", sep,
-                request.groupBy.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.limit)
-            url ~= format("%slimit=%s", sep, request.limit), sep = "&";
-        if (request.page.length)
-            url ~= format("%spage=%s", sep, encodeComponent(request.page)), sep = "&";
-        if (request.batch)
-            url ~= format("%sbatch=true", sep);
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/usage/" ~ type));
+        b.add("start_time", request.startTime);
+        b.add("end_time", request.endTime);
+        b.add("bucket_width", request.bucketWidth);
+        b.add("project_ids", request.projectIds);
+        b.add("user_ids", request.userIds);
+        b.add("api_key_ids", request.apiKeyIds);
+        b.add("models", request.models);
+        b.add("group_by", request.groupBy);
+        b.add("limit", request.limit);
+        b.add("page", request.page);
+        b.add("batch", request.batch);
+        return b.finish();
     }
 
     private string buildListCostsUrl(in ListCostsRequest request) const @safe
     {
-        import std.format : format;
-        import std.algorithm : map;
-        import std.uri : encodeComponent;
-
-        string url = buildUrl("/organization/costs");
-        string sep = "?";
-        url ~= format("%sstart_time=%s", sep, request.startTime);
-        sep = "&";
-        if (request.endTime)
-            url ~= format("%send_time=%s", sep, request.endTime), sep = "&";
-        if (request.bucketWidth.length)
-            url ~= format("%sbucket_width=%s", sep, encodeComponent(request.bucketWidth)), sep = "&";
-        if (request.projectIds !is null && request.projectIds.length)
-            url ~= format("%sproject_ids=%s", sep,
-                request.projectIds.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.groupBy !is null && request.groupBy.length)
-            url ~= format("%sgroup_by=%s", sep,
-                request.groupBy.map!encodeComponent.joiner(",")), sep = "&";
-        if (request.limit)
-            url ~= format("%slimit=%s", sep, request.limit), sep = "&";
-        if (request.page.length)
-            url ~= format("%spage=%s", sep, encodeComponent(request.page));
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/costs"));
+        b.add("start_time", request.startTime);
+        b.add("end_time", request.endTime);
+        b.add("bucket_width", request.bucketWidth);
+        b.add("project_ids", request.projectIds);
+        b.add("group_by", request.groupBy);
+        b.add("limit", request.limit);
+        b.add("page", request.page);
+        return b.finish();
     }
 
     private string buildListInvitesUrl(in ListInvitesRequest request) const @safe
     {
-        import std.format : format;
-        import std.uri : encodeComponent;
-
-        string url = buildUrl("/organization/invites");
-        string sep = "?";
-        if (request.limit)
-        {
-            url ~= format("%slimit=%s", sep, request.limit);
-            sep = "&";
-        }
-        if (request.after.length)
-            url ~= format("%safter=%s", sep, encodeComponent(request.after));
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/invites"));
+        b.add("limit", request.limit);
+        b.add("after", request.after);
+        return b.finish();
     }
 
     private string buildListUsersUrl(in ListUsersRequest request) const @safe
     {
-        import std.format : format;
-        import std.uri : encodeComponent;
-
-        string url = buildUrl("/organization/users");
-        string sep = "?";
-        if (request.limit)
-        {
-            url ~= format("%slimit=%s", sep, request.limit);
-            sep = "&";
-        }
-        if (request.after.length)
-            url ~= format("%safter=%s", sep, encodeComponent(request.after));
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/users"));
+        b.add("limit", request.limit);
+        b.add("after", request.after);
+        return b.finish();
     }
 
     private string buildListProjectUsersUrl(string projectId, in ListProjectUsersRequest request) const @safe
     {
-        import std.format : format;
-        import std.uri : encodeComponent;
-
-        string url = buildUrl("/organization/projects/" ~ projectId ~ "/users");
-        string sep = "?";
-        if (request.limit)
-        {
-            url ~= format("%slimit=%s", sep, request.limit);
-            sep = "&";
-        }
-        if (request.after.length)
-            url ~= format("%safter=%s", sep, encodeComponent(request.after));
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/projects/" ~ projectId ~ "/users"));
+        b.add("limit", request.limit);
+        b.add("after", request.after);
+        return b.finish();
     }
 
     private string buildListProjectServiceAccountsUrl(string projectId, in ListProjectServiceAccountsRequest request) const @safe
     {
-        import std.format : format;
-        import std.uri : encodeComponent;
-
-        string url = buildUrl("/organization/projects/" ~ projectId ~ "/service_accounts");
-        string sep = "?";
-        if (request.limit)
-        {
-            url ~= format("%slimit=%s", sep, request.limit);
-            sep = "&";
-        }
-        if (request.after.length)
-            url ~= format("%safter=%s", sep, encodeComponent(request.after));
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/projects/" ~ projectId ~ "/service_accounts"));
+        b.add("limit", request.limit);
+        b.add("after", request.after);
+        return b.finish();
     }
 
     private string buildListProjectRateLimitsUrl(string projectId, in ListProjectRateLimitsRequest request) const @safe
     {
-        import std.format : format;
-        import std.uri : encodeComponent;
-
-        string url = buildUrl("/organization/projects/" ~ projectId ~ "/rate_limits");
-        string sep = "?";
-        if (request.limit)
-        {
-            url ~= format("%slimit=%s", sep, request.limit);
-            sep = "&";
-        }
-        if (request.after.length)
-            url ~= format("%safter=%s", sep, encodeComponent(request.after));
-        return url;
+        auto b = QueryParamsBuilder(buildUrl("/organization/projects/" ~ projectId ~ "/rate_limits"));
+        b.add("limit", request.limit);
+        b.add("after", request.after);
+        return b.finish();
     }
 
     private void setupHttpByConfig(scope ref HTTP http) @system


### PR DESCRIPTION
## Summary
- move `QueryParamsBuilder` into `openai.clients.helpers`
- tighten static assertion for compile-time validity
- add a development reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6855421375b8832c88342a1a00f077c5