### PR TITLE
[clients] centralize config validation

### DIFF
--- a/.agents/reflections/2025-06-20-1223-config-validation-method.md
+++ b/.agents/reflections/2025-06-20-1223-config-validation-method.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 12:23]
+  - **Task**: Add validate method to configuration and update clients
+  - **Objective**: Centralize configuration checks and use them in clients
+  - **Outcome**: Added new method, removed duplicate client code, tests pass
+
+#### :sparkles: What went well
+  - The change simplified constructors by removing redundant code
+  - Automated formatting and linting kept code style consistent
+
+#### :warning: Pain points
+  - Running example builds took noticeable time on each cycle
+  - Linter installation logs cluttered console output
+
+#### :bulb: Proposed Improvement
+  - Provide a cached build directory for examples to speed up iterative testing

--- a/source/openai/clients/admin.d
+++ b/source/openai/clients/admin.d
@@ -20,7 +20,7 @@ class OpenAIAdminClient
     this()
     {
         this.config = OpenAIClientConfig.fromEnvironment();
-        validateConfig();
+        config.validate();
         enforce(!config.isAzure, "Administration API is not supported on Azure");
     }
 
@@ -28,19 +28,8 @@ class OpenAIAdminClient
     in (config !is null)
     {
         this.config = config;
-        validateConfig();
+        this.config.validate();
         enforce(!this.config.isAzure, "Administration API is not supported on Azure");
-    }
-
-private:
-    void validateConfig()
-    {
-        enforce(config.apiKey.length > 0, "OPENAI_API_KEY is required");
-        if (config.isAzure)
-        {
-            enforce(config.deploymentId.length > 0,
-                "OPENAI_DEPLOYMENT_ID is required for Azure mode");
-        }
     }
 
     string buildListAuditLogsUrl(in ListAuditLogsRequest request) const @safe

--- a/source/openai/clients/config.d
+++ b/source/openai/clients/config.d
@@ -42,6 +42,23 @@ class OpenAIClientConfig
         return apiBase.canFind(".api.cognitive.microsoft.com");
     }
 
+    /// Validate the configuration fields.
+    ///
+    /// Ensures that `apiKey` is present and, when using Azure endpoints,
+    /// that `deploymentId` is also provided.
+    void validate() const
+    {
+        import std.exception : enforce;
+
+        enforce(apiKey.length > 0, "OPENAI_API_KEY is required");
+
+        if (isAzure)
+        {
+            enforce(deploymentId.length > 0,
+                "OPENAI_DEPLOYMENT_ID is required for Azure mode");
+        }
+    }
+
     package this()
     {
         this.apiBase = "https://api.openai.com/v1";

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -35,7 +35,7 @@ class OpenAIClient
     this()
     {
         this.config = OpenAIClientConfig.fromEnvironment();
-        validateConfig();
+        config.validate();
     }
 
     ///
@@ -44,21 +44,7 @@ class OpenAIClient
     do
     {
         this.config = config;
-        validateConfig();
-    }
-
-    private void validateConfig()
-    {
-        import std.exception : enforce;
-
-        enforce(config.apiKey.length > 0,
-            "OPENAI_API_KEY is required");
-
-        if (config.isAzure)
-        {
-            enforce(config.deploymentId.length > 0,
-                "OPENAI_DEPLOYMENT_ID is required for Azure mode");
-        }
+        this.config.validate();
     }
 
     mixin ClientHelpers;


### PR DESCRIPTION
## Summary
- add `validate` to `OpenAIClientConfig`
- use the new method in `OpenAIClient` and `OpenAIAdminClient`
- document reflection for this task

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6855516ed320832c8156ab32b0838480