### PR TITLE
[admin] mark module @safe

### DIFF
--- a/.agents/reflections/2025-06-20-1259-admin-safe.md
+++ b/.agents/reflections/2025-06-20-1259-admin-safe.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-20 12:59]
+  - **Task**: Mark OpenAIAdminClient module @safe by default
+  - **Objective**: Align safety annotations with openai.d
+  - **Outcome**: Added @safe: after imports and verified build/test success
+
+#### :sparkles: What went well
+  - Automated formatting kept style consistent
+  - Existing tests ensured no regressions
+
+#### :warning: Pain points
+  - Example build produced temporary artifacts that needed cleanup
+  - Linter and formatter downloads increased build time in CI-like environment
+
+#### :bulb: Proposed Improvement
+  - Provide a cleanup script in scripts/build_examples.sh to remove artifacts automatically
+  - Cache dfmt and dscanner builds between runs to avoid redundant compilation

--- a/source/openai/clients/admin.d
+++ b/source/openai/clients/admin.d
@@ -13,6 +13,8 @@ import openai.clients.config : OpenAIClientConfig;
 
 import openai.clients.helpers; // for ClientHelpers mixin
 
+@safe:
+
 class OpenAIAdminClient
 {
     OpenAIClientConfig config;


### PR DESCRIPTION
## Summary
- apply `@safe:` to `OpenAIAdminClient` module
- document reflection on marking the admin module safe

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_68555a0c49d8832ca39c83776c251cc6