### PR TITLE
[clients] share multipart helpers

### DIFF
--- a/.agents/reflections/2025-06-20-1303-move-multipart-helpers.md
+++ b/.agents/reflections/2025-06-20-1303-move-multipart-helpers.md
@@ -1,0 +1,17 @@
+### :book: Reflection for [2025-06-20 13:03]
+  - **Task**: Move multipart helpers
+  - **Objective**: Share multipart utilities between clients
+  - **Outcome**: Functions relocated to `openai.clients.helpers` and tests updated
+
+#### :sparkles: What went well
+  - Formatter and linter ran smoothly
+  - Example build script helped confirm no regressions
+
+#### :warning: Pain points
+  - Cleaning generated example binaries after the build step took extra commands
+  - Initial linter run failed due to unused variables in tests
+
+#### :bulb: Proposed Improvement
+  - Extend `build_examples.sh` with a cleanup option to remove binaries automatically
+  - Add a pre-lint step that flags unused variables during test updates
+


### PR DESCRIPTION
## Summary
- share multipart helpers in `openai.clients.helpers`
- update OpenAI client and tests
- add reflection

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`
- `dub lint --dscanner-config dscanner.ini`


------
https://chatgpt.com/codex/tasks/task_e_68555a124c94832cb1222b702507b9eb