### PR TITLE
[admin] add helpers for admin key/project list

### DIFF
--- a/.codex/reflections/2025-06-20-1358-admin-url-builders-test.md
+++ b/.codex/reflections/2025-06-20-1358-admin-url-builders-test.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-20 13:58]
+  - **Task**: Add admin API helper builders and tests
+  - **Objective**: Implement reusable URL builders for admin endpoints and ensure encoding works
+  - **Outcome**: Added helper methods, refactored client functions, and extended tests successfully
+
+#### :sparkles: What went well
+  - Automated code formatting and linting kept style consistent
+  - Unit tests verified new query parameter handling
+
+#### :warning: Pain points
+  - `dub lint` and `dub test` compilation time was long on the container environment
+  - Example build output cluttered the git status and required cleanup
+
+#### :bulb: Proposed Improvement
+  - Provide a script to clean example artifacts automatically after builds
+  - 

--- a/source/openai/clients/helpers.d
+++ b/source/openai/clients/helpers.d
@@ -81,7 +81,8 @@ struct QueryParamsBuilder
     string value;
 }
 
-@system void appendFileChunked(scope ref Appender!(ubyte[]) 
+@system void appendFileChunked(scope ref Appender!(ubyte[])
+    
     body,
     string boundary,
     string name,


### PR DESCRIPTION
## Summary
- add URL builder helpers for admin API key and project listing
- refactor list methods to use helpers
- test query encoding for the new builders
- format codebase
- reflect on adding admin helpers

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `scripts/build_examples.sh core`


------
https://chatgpt.com/codex/tasks/task_e_6855672eb558832cbbd543c7a46ad972