### PR TITLE
[clients] remove unused import

### DIFF
--- a/.codex/reflections/2025-06-20-1409-remove-unused-administration-import.md
+++ b/.codex/reflections/2025-06-20-1409-remove-unused-administration-import.md
@@ -1,0 +1,16 @@
+### :book: Reflection for [2025-06-20 14:09]
+  - **Task**: remove unused administration import
+  - **Objective**: Clean up unused imports in OpenAI client module
+  - **Outcome**: Removed the administration module import and verified build
+
+#### :sparkles: What went well
+  - Automated formatting and linting caught no new issues
+  - Tests and example builds ran successfully
+
+#### :warning: Pain points
+  - Building examples pulled additional dependencies, slightly slowing feedback
+  - Coverage generation produced many files to inspect manually
+
+#### :bulb: Proposed Improvement
+  - Provide a make target that runs formatter, linter, tests, and coverage in one step
+

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -17,7 +17,6 @@ import openai.audio;
 import openai.images;
 import openai.files;
 import openai.responses;
-import openai.administration;
 import openai.clients.helpers;
 import openai.clients.config;
 


### PR DESCRIPTION
## Summary
- remove unused administration import from OpenAI client
- add reflection entry for change

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_685569c43cd0832c94f8cfa13ef014a7