### PR TITLE
[clients] rename admin client file

### DIFF
--- a/.codex/reflections/2025-06-20-1441-rename-admin-client.md
+++ b/.codex/reflections/2025-06-20-1441-rename-admin-client.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 14:41]
+- **Task**: Rename admin client file
+- **Objective**: Align module naming with project conventions by renaming clients/admin.d
+- **Outcome**: Renamed file and updated imports; all tests and examples still build.
+
+#### :sparkles: What went well
+- Automated formatting and linting ensured style consistency.
+- Comprehensive example build confirmed library stability after rename.
+
+#### :warning: Pain points
+- Building all examples was slow due to compiling many dependencies locally.
+- `git clean` needed after builds to remove generated artifacts.
+
+#### :bulb: Proposed Improvement
+- Provide a script to clean build artifacts and revert dub selections automatically after example builds.

--- a/source/openai/clients/openai_admin.d
+++ b/source/openai/clients/openai_admin.d
@@ -1,4 +1,4 @@
-module openai.clients.admin;
+module openai.clients.openai_admin;
 
 import std.net.curl;
 import std.format;

--- a/source/openai/package.d
+++ b/source/openai/package.d
@@ -5,7 +5,7 @@ module openai;
 
 public import openai.clients.config;
 public import openai.clients.openai;
-public import openai.clients.admin;
+public import openai.clients.openai_admin;
 
 public import openai.common;
 


### PR DESCRIPTION
## Summary
- rename `clients/admin.d` to `clients/openai_admin.d`
- update public import
- add reflection entry

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d all`


------
https://chatgpt.com/codex/tasks/task_e_6855713c1b10832c991086ef665827e1