### PR TITLE
[helpers] fix dfmt newline in helper

### DIFF
--- a/.codex/reflections/2025-06-20-1514-fix-linebreak-in-appendfilechunked.md
+++ b/.codex/reflections/2025-06-20-1514-fix-linebreak-in-appendfilechunked.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 15:14]
+  - **Task**: Fix CI formatter failure due to extra newline
+  - **Objective**: Ensure formatter output matches committed sources
+  - **Outcome**: Ran dfmt which added expected blank lines and committed the change; CI should now pass
+
+#### :sparkles: What went well
+  - Automation with dfmt quickly reformatted the file
+  - Running tests and example builds verified no regressions
+
+#### :warning: Pain points
+  - Formatter installation prints many warnings which clutter logs
+  - Example builds take considerable time in the container
+
+#### :bulb: Proposed Improvement
+  - Provide prebuilt dfmt and dscanner binaries in the environment to speed up runs

--- a/source/openai/clients/helpers.d
+++ b/source/openai/clients/helpers.d
@@ -82,7 +82,9 @@ struct QueryParamsBuilder
 }
 
 @system void appendFileChunked(scope ref Appender!(ubyte[])
+
     
+
     body,
     string boundary,
     string name,


### PR DESCRIPTION
## Summary
- run dfmt on `helpers.d`
- add reflection for the newline formatting fix

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `rdmd scripts/build_examples.d core`


------
https://chatgpt.com/codex/tasks/task_e_685579b20164832caaccdcb9d16a5395