### PR TITLE
[scripts] add build cleanup option

### DIFF
--- a/.codex/reflections/2025-06-20-1537-clean-examples-flag.md
+++ b/.codex/reflections/2025-06-20-1537-clean-examples-flag.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 15:37]
+  - **Task**: Add cleanup option to build script
+  - **Objective**: Provide an easy way to remove example build artifacts
+  - **Outcome**: Implemented `--clean` flag and documented its use
+
+#### :sparkles: What went well
+  - Dfmt kept formatting consistent
+  - Cleaning removed all unwanted files as expected
+
+#### :warning: Pain points
+  - Linter and coverage steps were slow due to repeated dependency compilation
+  - `dub clean` didn't remove binaries, requiring manual deletion
+
+#### :bulb: Proposed Improvement
+  - Cache dependencies for tooling like dfmt and dscanner to speed up checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,15 @@
    3. To mirror CI or prepare a full release, you can still build **all**:
 
       ```bash
-       rdmd scripts/build_examples.d all
+      rdmd scripts/build_examples.d all
       ```
-5. If all checks pass, commit changes and open a pull request.
+   4. To remove `dub.selections.json` and build artifacts after compiling, pass
+      the `--clean` flag:
+
+      ```bash
+       rdmd scripts/build_examples.d core <group> --clean
+      ```
+   5. If all checks pass, commit changes and open a pull request.
 
 ## 8. CI/CD & PR Guidelines
 

--- a/scripts/build_examples.d
+++ b/scripts/build_examples.d
@@ -6,8 +6,6 @@ import std.algorithm : sort, canFind, filter, map;
 import std.string;
 import std.process;
 import core.stdc.stdlib : exit;
-import std.algorithm.searching : endsWith;
-
 void main(string[] args)
 {
     auto scriptDir = dirName(__FILE__).absolutePath;

--- a/scripts/build_examples.d
+++ b/scripts/build_examples.d
@@ -96,7 +96,12 @@ void main(string[] args)
         if (clean)
         {
             auto cleanPid = spawnProcess(["dub", "clean"], null, Config.none, workDir);
-            wait(cleanPid);
+            auto cleanStatus = wait(cleanPid);
+            if (cleanStatus != 0)
+            {
+                writeln("dub clean failed for " ~ dir);
+                exit(cleanStatus);
+            }
 
             string bin = buildPath(workDir, dir);
             if (exists(bin))


### PR DESCRIPTION
## Summary
- add `--clean` flag to `scripts/build_examples.d` to remove build artifacts
- document example cleanup in `AGENTS.md`
- record reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub run dfmt -- scripts`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d core chat --clean`

------
https://chatgpt.com/codex/tasks/task_e_68557eaf1c34832c92f2f25b3c97cda2