### PR TITLE
[build] update example dependencies for ldc

### DIFF
--- a/.codex/reflections/2025-06-20-1555-update-example-dependencies.md
+++ b/.codex/reflections/2025-06-20-1555-update-example-dependencies.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 15:55]
+  - **Task**: Resolve CI failure on Ubuntu with ldc-latest
+  - **Objective**: Investigate linker errors and ensure build succeeds
+  - **Outcome**: Updated example dependency locks to match library versions which fixed the issue
+
+#### :sparkles: What went well
+  - The build tools made it easy to format, lint and build all examples
+  - Automated scripts simplified compiling many sample applications
+
+#### :warning: Pain points
+  - The CI failure was hard to reproduce locally due to compiler version differences
+  - Updating many dub.selections files manually felt repetitive and error-prone
+
+#### :bulb: Proposed Improvement
+  - Provide a script to synchronize dependency versions across examples

--- a/examples/administration/dub.selections.json
+++ b/examples/administration/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_api_keys/dub.selections.json
+++ b/examples/administration_api_keys/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_audit_logs/dub.selections.json
+++ b/examples/administration_audit_logs/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_certificates/dub.selections.json
+++ b/examples/administration_certificates/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_invites/dub.selections.json
+++ b/examples/administration_invites/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_project_api_keys/dub.selections.json
+++ b/examples/administration_project_api_keys/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
-                "mir-ion": "2.3.4",
-                "openai-d": {"path":"../.."}
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_project_rate_limits/dub.selections.json
+++ b/examples/administration_project_rate_limits/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
-                "mir-ion": "2.3.4",
-                "openai-d": {"path":"../.."}
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_project_service_accounts/dub.selections.json
+++ b/examples/administration_project_service_accounts/dub.selections.json
@@ -1,10 +1,11 @@
 {
-        "fileVersion": 1,
-        "versions": {
-                "mir-algorithm": "3.22.3",
-                "mir-core": "1.7.1",
-                "mir-cpuid": "1.2.11",
-                "mir-ion": "2.3.4",
-                "openai-d": {"path":"../.."}
-        }
+	"fileVersion": 1,
+	"versions": {
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
+		"mir-cpuid": "1.2.11",
+		"mir-ion": "2.3.4",
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
+	}
 }

--- a/examples/administration_project_users/dub.selections.json
+++ b/examples/administration_project_users/dub.selections.json
@@ -1,8 +1,8 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
 		"openai-d": {"path":"../.."},

--- a/examples/administration_projects/dub.selections.json
+++ b/examples/administration_projects/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_usage/dub.selections.json
+++ b/examples/administration_usage/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/administration_users/dub.selections.json
+++ b/examples/administration_users/dub.selections.json
@@ -1,8 +1,8 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
 		"openai-d": {"path":"../.."},

--- a/examples/audio_speech/dub.selections.json
+++ b/examples/audio_speech/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/audio_transcription/dub.selections.json
+++ b/examples/audio_transcription/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/audio_translation/dub.selections.json
+++ b/examples/audio_translation/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/chat/dub.selections.json
+++ b/examples/chat/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/chat_db/dub.selections.json
+++ b/examples/chat_db/dub.selections.json
@@ -2,10 +2,11 @@
 	"fileVersion": 1,
 	"versions": {
 		"d2sqlite3": "1.0.0",
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/chat_reasoning/dub.selections.json
+++ b/examples/chat_reasoning/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/chat_structured_output/dub.selections.json
+++ b/examples/chat_structured_output/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/chat_tools/dub.selections.json
+++ b/examples/chat_tools/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/chat_vision/dub.selections.json
+++ b/examples/chat_vision/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/completion/dub.selections.json
+++ b/examples/completion/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/embedding/dub.selections.json
+++ b/examples/embedding/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/models/dub.selections.json
+++ b/examples/models/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/moderation/dub.selections.json
+++ b/examples/moderation/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/responses/dub.selections.json
+++ b/examples/responses/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/responses_code_interpreter/dub.selections.json
+++ b/examples/responses_code_interpreter/dub.selections.json
@@ -1,10 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mir-algorithm": "3.22.3",
-		"mir-core": "1.7.1",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }

--- a/examples/responses_web_search/dub.selections.json
+++ b/examples/responses_web_search/dub.selections.json
@@ -5,6 +5,7 @@
 		"mir-core": "1.7.3",
 		"mir-cpuid": "1.2.11",
 		"mir-ion": "2.3.4",
-		"openai-d": {"path":"../.."}
+		"openai-d": {"path":"../.."},
+		"silly": "1.1.1"
 	}
 }


### PR DESCRIPTION
## Summary
- update `dub.selections.json` files in all examples to use mir-core 1.7.3 and mir-algorithm 3.22.4
- add reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d all`

------
https://chatgpt.com/codex/tasks/task_e_685581e56690832c91ce324d3d62cea2