### PR TITLE
[docs] reflection archiving helper

### DIFF
--- a/.codex/reflections/AGENTS.md
+++ b/.codex/reflections/AGENTS.md
@@ -4,8 +4,7 @@ To keep the `reflections` directory tidy, archive a reflection once its improvem
 
 1. Review the reflection and locate the **Proposed Improvement**.
 2. Verify through commit history or existing features that the improvement was made.
-3. Move the file to `.codex/archive/` using `git mv`.
-4. Optionally append a short note in `.codex/archive/REFLECTION_HISTORY.md` describing the archive.
-5. Commit the move (and note) with message `docs: add reflection archiving workflow`.
+3. Run `rdmd scripts/archive_reflection.d <file>` to move the file to `.codex/archive/` and record a brief entry in `.codex/archive/REFLECTION_HISTORY.md`.
+4. Commit the move (and note) with message `docs: add reflection archiving workflow`.
 
 Each reflection's `Proposed Improvement` section must contain exactly one bullet describing the improvement. Remove any placeholder bullets before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ headers when modifying or archiving those files to maintain consistency.
 * Records are keyed by timestamp (to the minute). Use the current date and time as `YYYY-MM-DD HH:MM` in the template and file name.
 * Replace `{task-summary}` with a short hyphenated summary of the task.
 * When documenting pain points, include your environment (CI, local machine, OS, etc.) and specify which step or command was slow.
-* After your proposed improvement is implemented, move the reflection to `.codex/archive/`. See [`.codex/reflections/AGENTS.md`](.codex/reflections/AGENTS.md) for the full archiving workflow.
+* After your proposed improvement is implemented, run `rdmd scripts/archive_reflection.d <file>` to move the reflection to `.codex/archive/` and log the archive. See [`.codex/reflections/AGENTS.md`](.codex/reflections/AGENTS.md) for the full workflow.
 * Review all outstanding improvements:
 
   ```bash

--- a/scripts/archive_reflection.d
+++ b/scripts/archive_reflection.d
@@ -1,0 +1,52 @@
+import std.stdio;
+import std.file;
+import std.path;
+import std.process;
+import std.datetime;
+import std.string : replace;
+
+void main(string[] args)
+{
+    if (args.length != 2)
+    {
+        stderr.writeln("Usage: rdmd scripts/archive_reflection.d <reflection-file>");
+        return;
+    }
+
+    auto scriptDir = dirName(__FILE__).absolutePath;
+    auto rootDir = buildPath(scriptDir, "..");
+
+    string refPath = args[1];
+    if (!isAbsolute(refPath))
+        refPath = buildPath(rootDir, refPath);
+    refPath = buildNormalizedPath(refPath);
+    if (!exists(refPath))
+    {
+        stderr.writeln("Reflection not found: " ~ refPath);
+        return;
+    }
+
+    auto archiveDir = buildPath(rootDir, ".codex", "archive");
+    enforce(exists(archiveDir), "Archive directory missing: " ~ archiveDir);
+    string dest = buildPath(archiveDir, baseName(refPath));
+
+    auto mvPid = spawnProcess(["git", "mv", refPath, dest], rootDir);
+    auto status = wait(mvPid);
+    if (status != 0)
+        throw new Exception("git mv failed");
+
+    auto now = Clock.currTime();
+    auto ts = now.toISOExtString()[0 .. 16].replace("T", " ");
+    auto entry = format("- [%s] Archived %s\n", ts, baseName(refPath));
+
+    string historyPath = buildPath(archiveDir, "REFLECTION_HISTORY.md");
+    string existing = exists(historyPath) ? readText(historyPath) : "";
+    bool addNl = existing.length > 0 && !existing.endsWith("\n");
+
+    auto file = File(historyPath, "a");
+    if (addNl)
+        file.writeln();
+    file.write(entry);
+    file.close();
+}
+


### PR DESCRIPTION
## Summary
- create `scripts/archive_reflection.d` for moving a reflection file to the archive and logging the action
- document this helper in `.codex/reflections/AGENTS.md`
- mention the script in the root `AGENTS.md`

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_685583680b98832c81dc3555d50feed5