### PR TITLE
[docs] clarify quick experiment instructions

### DIFF
--- a/.codex/reflections/2025-06-20-1724-helper-script-docs.md
+++ b/.codex/reflections/2025-06-20-1724-helper-script-docs.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 17:24]
+  - **Task**: Document helper scripts and quick experiment workflow
+  - **Objective**: Clarify how to run project scripts and small D examples
+  - **Outcome**: Added new section in AGENTS.md describing rdmd usage, DUB single-file mode and planned dependency sync script
+
+#### :sparkles: What went well
+  - Documentation changes required no code updates
+  - The repository already had clear formatting guidelines
+
+#### :warning: Pain points
+  - Remembering the proper rdmd command for each script slows me down
+  - Creating each reflection file manually feels repetitive
+
+#### :bulb: Proposed Improvement
+  - Provide a template helper that generates reflection files with the current timestamp

--- a/.codex/reflections/2025-06-20-1733-simplify-quick-experiments.md
+++ b/.codex/reflections/2025-06-20-1733-simplify-quick-experiments.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-20 17:33]
+  - **Task**: Remove DUB single-file instructions
+  - **Objective**: Keep quick experiment guidance focused on rdmd
+  - **Outcome**: Updated AGENTS.md accordingly
+
+#### :sparkles: What went well
+  - Direct edit kept the documentation concise
+  - Tests and formatting ran without issues
+
+#### :warning: Pain points
+  - Building dfmt every run is slow on this container
+
+#### :bulb: Proposed Improvement
+  - Cache dfmt binaries to avoid rebuilding during formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,21 @@ headers when modifying or archiving those files to maintain consistency.
   ```bash
   rdmd scripts/list_reflections.d
   ```
+
+## 11. Helper Scripts and Quick Experiments
+
+* Run project scripts with `rdmd`:
+
+  ```bash
+  rdmd scripts/build_examples.d core
+  ```
+
+  Replace `build_examples.d` with any helper in `scripts`.
+
+* For quick experiments, run a single D file directly:
+
+  ```bash
+  rdmd path/to/file.d
+  ```
+
+* A helper for syncing example dependency locks is planned.


### PR DESCRIPTION
## Summary
- clarify rdmd usage for quick experiments
- add reflection on simplification of helper docs

## Testing
- `dub test`
- `dub run dfmt -- source examples`


------
https://chatgpt.com/codex/tasks/task_e_685598e7a438832cbb01ff326b3044cb