### PR TITLE
[docs] update AGENTS with dependency upgrade steps

### DIFF
--- a/.codex/reflections/2025-06-20-1749-dependency-update-procedure.md
+++ b/.codex/reflections/2025-06-20-1749-dependency-update-procedure.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-20 17:49]
+  - **Task**: Document efficient dependency update procedure
+  - **Objective**: Update AGENTS.md with steps for `dub add` and `dub upgrade`
+  - **Outcome**: Added new section describing how to upgrade all packages and verified tests
+
+#### :sparkles: What went well
+  - Repository already configured with dfmt, linter and tests, so verification was straightforward
+  - No actual dependency changes were needed
+
+#### :warning: Pain points
+  - `dub lint` downloads many packages on first run which slows down the workflow
+
+#### :bulb: Proposed Improvement
+  - Cache common tooling like `dscanner` in CI to avoid repeated fetches

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,3 +168,20 @@ headers when modifying or archiving those files to maintain consistency.
   ```
 
 * A helper for syncing example dependency locks is planned.
+## 12. Updating Dependencies
+
+* To add or update a dependency to the latest release in one command:
+
+  ```bash
+  dub add <package>@*
+  ```
+
+* To upgrade every dependency across the repository:
+
+  ```bash
+  dub upgrade --sub-packages
+  ```
+
+  This refreshes `dub.selections.json` with the newest versions.
+
+* After upgrading, run the formatter, linter, tests, and coverage before committing.


### PR DESCRIPTION
## Summary
- document how to update dependencies with `dub add` and `dub upgrade`
- add a reflection about documenting the procedure

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_68559e47a8fc832cbd1d95fd4964a8f5