### PR TITLE
[core] switch to mir Nullable

### DIFF
--- a/.codex/reflections/2025-06-20-2344-use-mir-nullable.md
+++ b/.codex/reflections/2025-06-20-2344-use-mir-nullable.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-20 23:44]
+  - **Task**: Replace std.typecons.Nullable with mir.algebraic.Nullable
+  - **Objective**: Remove leftover std imports and unify optional handling
+  - **Outcome**: All modules now import mir.algebraic and tests pass with coverage
+
+#### :sparkles: What went well
+  - Search and replace made it easy to clean up imports
+  - Formatter and linter found no further issues
+
+#### :warning: Pain points
+  - Coverage generation spawns many .lst files which clutter the workspace
+  - Building dfmt and dscanner on first run took noticeable time
+
+#### :bulb: Proposed Improvement
+  - Add a helper script to purge coverage files automatically after verification

--- a/source/openai/administration/api_keys.d
+++ b/source/openai/administration/api_keys.d
@@ -3,7 +3,6 @@ module openai.administration.api_keys;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/audit.d
+++ b/source/openai/administration/audit.d
@@ -3,7 +3,6 @@ module openai.administration.audit;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/certificates.d
+++ b/source/openai/administration/certificates.d
@@ -3,7 +3,6 @@ module openai.administration.certificates;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/invites.d
+++ b/source/openai/administration/invites.d
@@ -3,7 +3,6 @@ module openai.administration.invites;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/project_api_keys.d
+++ b/source/openai/administration/project_api_keys.d
@@ -3,7 +3,6 @@ module openai.administration.project_api_keys;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 public import openai.administration.api_keys : OwnerInfo;

--- a/source/openai/administration/project_rate_limits.d
+++ b/source/openai/administration/project_rate_limits.d
@@ -3,7 +3,6 @@ module openai.administration.project_rate_limits;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/project_service_accounts.d
+++ b/source/openai/administration/project_service_accounts.d
@@ -3,7 +3,6 @@ module openai.administration.project_service_accounts;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/projects.d
+++ b/source/openai/administration/projects.d
@@ -3,7 +3,6 @@ module openai.administration.projects;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/usage.d
+++ b/source/openai/administration/usage.d
@@ -3,7 +3,6 @@ module openai.administration.usage;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/administration/users.d
+++ b/source/openai/administration/users.d
@@ -3,7 +3,6 @@ module openai.administration.users;
 import mir.serde;
 import mir.serde : serdeEnumProxy;
 import mir.string_map;
-import std.typecons : Nullable;
 import mir.algebraic;
 
 @safe:

--- a/source/openai/files.d
+++ b/source/openai/files.d
@@ -6,7 +6,7 @@ Standards: https://platform.openai.com/docs/api-reference/files
 module openai.files;
 
 import mir.serde;
-import std.typecons : Nullable;
+import mir.algebraic;
 
 @safe:
 

--- a/source/openai/responses.d
+++ b/source/openai/responses.d
@@ -8,7 +8,6 @@ module openai.responses;
 import mir.algebraic;
 import mir.serde;
 import mir.string_map;
-import std.typecons : Nullable;
 
 import openai.common;
 import openai.chat : ChatMessageContent, ChatUserMessageContentItem,


### PR DESCRIPTION
## Summary
- remove `std.typecons.Nullable` imports
- use `mir.algebraic.Nullable`
- format with `dfmt`
- keep coverage numbers

## Testing
- `dub test`
- `dub lint --dscanner-config dscanner.ini`
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_6855f1af75b8832c8c779c89cda1ed05