### PR TITLE
[docs] add code-base insights section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,3 +185,11 @@ headers when modifying or archiving those files to maintain consistency.
   This refreshes `dub.selections.json` with the newest versions.
 
 * After upgrading, run the formatter, linter, tests, and coverage before committing.
+
+## 13. Code-Base Insights
+
+* Cache `dfmt` and `dscanner` binaries locally to avoid repeated downloads when running the formatter or linter.
+* Build examples with `rdmd scripts/build_examples.d core <group> --clean` to remove artifacts automatically. The script recognizes directories with underscores when provided explicitly.
+* Prefer `QueryParamsBuilder` (in `openai.clients.helpers`) for constructing URLs with optional query parameters.
+* Keep relevant OpenAPI spec snippets under `docs/` for quick reference.
+* Reflection files must use bracketed timestamps and a single bullet under **Proposed Improvement**.


### PR DESCRIPTION
## Summary
- capture insights from recent reflections in a new **Code-Base Insights** section of `AGENTS.md`
- document caching of tooling, example build script tips, use of `QueryParamsBuilder`, OpenAPI docs, and reflection formatting

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_685615b73990832c9026c6b30176e7b7