### PR TITLE
[administration] fix numeric literal readability

### DIFF
--- a/.codex/reflections/2025-06-21-1528-lint-number-formatting.md
+++ b/.codex/reflections/2025-06-21-1528-lint-number-formatting.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-21 15:28]
+  - **Task**: Fix linter warnings
+  - **Objective**: Ensure code passes dscanner style checks
+  - **Outcome**: Updated numeric literals with underscores and verified tests pass
+
+#### :sparkles: What went well
+  - Automated linting quickly pointed out formatting issues
+  - Formatter and linter integration ensured consistent style
+
+#### :warning: Pain points
+  - Linter initially failed with minimal context about the warnings
+  - Rebuilding dscanner each run slowed feedback slightly in this environment
+
+#### :bulb: Proposed Improvement
+  - Cache dscanner binaries between runs to speed up linting

--- a/source/openai/administration/invites.d
+++ b/source/openai/administration/invites.d
@@ -125,8 +125,8 @@ unittest
     assert(list.data[0].email == "user@example.com");
     assert(list.data[0].role == "owner");
     assert(list.data[0].status == InviteStatus.Pending);
-    assert(list.data[0].createdAt == 1750481517);
-    assert(list.data[0].expiresAt == 1751086317);
+    assert(list.data[0].createdAt == 1_750_481_517);
+    assert(list.data[0].expiresAt == 1_751_086_317);
     assert(list.data[0].acceptedAt.isNull);
     assert(list.data[0].projects.length == 0);
     assert(list.firstId == "invite-id");

--- a/source/openai/administration/project_api_keys.d
+++ b/source/openai/administration/project_api_keys.d
@@ -220,6 +220,6 @@ unittest
     assert(list.data[2].owner.get!(ProjectApiKeyOwnerUser).user.email == "user@example.com");
     assert(list.data[3].owner.get!(ProjectApiKeyOwnerServiceAccount).serviceAccount.id == "user-service_account1");
     assert(list.data[3].owner.get!(ProjectApiKeyOwnerServiceAccount).serviceAccount.name == "My Service Account Key");
-    assert(list.data[3].owner.get!(ProjectApiKeyOwnerServiceAccount).serviceAccount.createdAt == 1750494142);
+    assert(list.data[3].owner.get!(ProjectApiKeyOwnerServiceAccount).serviceAccount.createdAt == 1_750_494_142);
     assert(list.data[3].owner.get!(ProjectApiKeyOwnerServiceAccount).serviceAccount.role == "owner");
 }


### PR DESCRIPTION
## Summary
- update numeric literals in tests to use underscores
- add reflection about linting fix

## Testing
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d core administration`


------
https://chatgpt.com/codex/tasks/task_e_6856ce9baab4832cba9b9185855c4006