### PR TITLE
[administration] rename admin api key file

### DIFF
--- a/.codex/reflections/2025-06-21-2121-rename-admin-api-key-file.md
+++ b/.codex/reflections/2025-06-21-2121-rename-admin-api-key-file.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-21 21:21]
+  - **Task**: Rename administration/api_key.d to administration/admin_api_key.d
+  - **Objective**: Ensure the code base uses consistent naming for admin API key module and passes all checks
+  - **Outcome**: File renamed, imports updated, and all tests and builds succeeded
+
+#### :sparkles: What went well
+  - `dub` tools handled the rename smoothly
+  - Automated formatting and linting ran without issues
+
+#### :warning: Pain points
+  - Linting and formatting took noticeable time due to dependency compilation in this environment
+
+#### :bulb: Proposed Improvement
+  - Cache `dfmt` and `dscanner` binaries to avoid rebuild delays

--- a/source/openai/administration/admin_api_key.d
+++ b/source/openai/administration/admin_api_key.d
@@ -1,4 +1,4 @@
-module openai.administration.api_keys;
+module openai.administration.admin_api_key;
 
 import mir.serde;
 import mir.serde : serdeEnumProxy;

--- a/source/openai/administration/package.d
+++ b/source/openai/administration/package.d
@@ -1,6 +1,6 @@
 module openai.administration;
 
-public import openai.administration.api_keys;
+public import openai.administration.admin_api_key;
 public import openai.administration.projects;
 public import openai.administration.project_api_keys;
 public import openai.administration.project_service_accounts;


### PR DESCRIPTION
## Summary
- rename `api_keys.d` to `admin_api_key.d`
- update administration package import
- add reflection on renaming admin api key file

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d core`


------
https://chatgpt.com/codex/tasks/task_e_68572096c150832c8e53cd39ec6db844