### PR TITLE
[administration] add optional after helpers

### DIFF
--- a/.codex/reflections/2025-06-21-2158-helper-overloads.md
+++ b/.codex/reflections/2025-06-21-2158-helper-overloads.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-21 21:58]
+- **Task**: Add overloaded helper constructors with optional parameters
+- **Objective**: Provide easier API usage for list requests
+- **Outcome**: Updated several modules, added tests and ran all checks
+
+#### :sparkles: What went well
+- Smooth integration of new helpers across modules
+- Unit tests ensured serialization was correct
+
+#### :warning: Pain points
+- Running dfmt and dscanner caused lengthy dependency builds in CI environment
+- Large source files made navigation slower
+
+#### :bulb: Proposed Improvement
+- Cache dfmt and dscanner binaries in the build environment to avoid rebuilds

--- a/source/openai/administration/admin_api_key.d
+++ b/source/openai/administration/admin_api_key.d
@@ -59,6 +59,14 @@ ListAdminApiKeysRequest listAdminApiKeysRequest(uint limit)
     return req;
 }
 
+/// ditto
+ListAdminApiKeysRequest listAdminApiKeysRequest(uint limit, string after)
+{
+    auto req = listAdminApiKeysRequest(limit);
+    req.after = after;
+    return req;
+}
+
 struct CreateAdminApiKeyRequest
 {
     string name;
@@ -96,6 +104,14 @@ unittest
 
     auto req = createAdminApiKeyRequest("main-key");
     assert(serializeJson(req) == `{"name":"main-key"}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = listAdminApiKeysRequest(5, "k1");
+    assert(serializeJson(req) == `{"after":"k1","limit":5}`);
 }
 
 unittest

--- a/source/openai/administration/invites.d
+++ b/source/openai/administration/invites.d
@@ -66,6 +66,14 @@ ListInvitesRequest listInvitesRequest(uint limit)
     return req;
 }
 
+/// ditto
+ListInvitesRequest listInvitesRequest(uint limit, string after)
+{
+    auto req = listInvitesRequest(limit);
+    req.after = after;
+    return req;
+}
+
 struct InviteRequest
 {
     string email;
@@ -94,6 +102,14 @@ unittest
 
     auto req = inviteRequest("user@example.com", "owner");
     assert(serializeJson(req) == `{"email":"user@example.com","role":"owner"}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = listInvitesRequest(5, "next");
+    assert(serializeJson(req) == `{"limit":5,"after":"next"}`);
 }
 
 unittest

--- a/source/openai/administration/project_rate_limits.d
+++ b/source/openai/administration/project_rate_limits.d
@@ -44,6 +44,14 @@ ListProjectRateLimitsRequest listProjectRateLimitsRequest(uint limit)
     return req;
 }
 
+/// ditto
+ListProjectRateLimitsRequest listProjectRateLimitsRequest(uint limit, string after)
+{
+    auto req = listProjectRateLimitsRequest(limit);
+    req.after = after;
+    return req;
+}
+
 struct CreateProjectRateLimitRequest
 {
     @serdeKeys("max_requests_per_1_minute") long maxRequestsPer1Minute;
@@ -121,6 +129,8 @@ unittest
 
     auto lreq = listProjectRateLimitsRequest(5);
     assert(serializeJson(lreq) == `{"limit":5}`);
+    auto lafter = listProjectRateLimitsRequest(5, "last");
+    assert(serializeJson(lafter) == `{"limit":5,"after":"last"}`);
 
     auto creq = createProjectRateLimitRequest(1, 2, 3, 4, 5, 6);
     assert(serializeJson(creq) == `{"max_requests_per_1_minute":1,"max_tokens_per_1_minute":2,"max_images_per_1_minute":3,"max_audio_megabytes_per_1_minute":4,"max_requests_per_1_day":5,"batch_1_day_max_input_tokens":6}`);

--- a/source/openai/administration/project_service_accounts.d
+++ b/source/openai/administration/project_service_accounts.d
@@ -82,6 +82,14 @@ ListProjectServiceAccountsRequest listProjectServiceAccountsRequest(uint limit)
     return req;
 }
 
+/// ditto
+ListProjectServiceAccountsRequest listProjectServiceAccountsRequest(uint limit, string after)
+{
+    auto req = listProjectServiceAccountsRequest(limit);
+    req.after = after;
+    return req;
+}
+
 unittest
 {
     import mir.deser.json : deserializeJson;
@@ -105,6 +113,8 @@ unittest
 
     auto lreq = listProjectServiceAccountsRequest(5);
     assert(serializeJson(lreq) == `{"limit":5}`);
+    auto lafter = listProjectServiceAccountsRequest(5, "id_1");
+    assert(serializeJson(lafter) == `{"limit":5,"after":"id_1"}`);
     auto creq = createProjectServiceAccountRequest("My SA");
     assert(serializeJson(creq) == `{"name":"My SA"}`);
 }

--- a/source/openai/administration/projects.d
+++ b/source/openai/administration/projects.d
@@ -45,6 +45,14 @@ ListProjectsRequest listProjectsRequest(uint limit, bool includeArchived = false
     return req;
 }
 
+/// ditto
+ListProjectsRequest listProjectsRequest(uint limit, bool includeArchived, string after)
+{
+    auto req = listProjectsRequest(limit, includeArchived);
+    req.after = after;
+    return req;
+}
+
 struct CreateProjectRequest
 {
     string name;
@@ -90,4 +98,12 @@ unittest
 
     auto req = listProjectsRequest(10, true);
     assert(serializeJson(req) == `{"limit":10,"include_archived":true}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = listProjectsRequest(10, false, "x");
+    assert(serializeJson(req) == `{"limit":10,"after":"x"}`);
 }

--- a/source/openai/administration/users.d
+++ b/source/openai/administration/users.d
@@ -132,11 +132,27 @@ ListProjectUsersRequest listProjectUsersRequest(uint limit)
     return req;
 }
 
+/// ditto
+ListProjectUsersRequest listProjectUsersRequest(uint limit, string after)
+{
+    auto req = listProjectUsersRequest(limit);
+    req.after = after;
+    return req;
+}
+
 /// Convenience constructor for `ListUsersRequest`.
 ListUsersRequest listUsersRequest(uint limit)
 {
     auto req = ListUsersRequest();
     req.limit = limit;
+    return req;
+}
+
+/// ditto
+ListUsersRequest listUsersRequest(uint limit, string after)
+{
+    auto req = listUsersRequest(limit);
+    req.after = after;
     return req;
 }
 
@@ -157,6 +173,8 @@ unittest
 
     auto req = listUsersRequest(10);
     assert(serializeJson(req) == `{"limit":10}`);
+    auto reqA = listUsersRequest(10, "id_a");
+    assert(serializeJson(reqA) == `{"limit":10,"after":"id_a"}`);
     auto role = updateUserRoleRequest(ProjectUserRole.Owner);
     assert(serializeJson(role) == `{"role":"owner"}`);
 }
@@ -179,6 +197,8 @@ unittest
 
     auto lreq = listProjectUsersRequest(5);
     assert(serializeJson(lreq) == `{"limit":5}`);
+    auto lreqAfter = listProjectUsersRequest(5, "next");
+    assert(serializeJson(lreqAfter) == `{"limit":5,"after":"next"}`);
     auto creq = createProjectUserRequest("user_abc", ProjectUserRole.Member);
     assert(serializeJson(creq) == `{"user_id":"user_abc","role":"member"}`);
     auto ureq = updateProjectUserRequest(ProjectUserRole.Owner);

--- a/source/openai/files.d
+++ b/source/openai/files.d
@@ -61,6 +61,21 @@ ListFilesRequest listFilesRequest()
     return ListFilesRequest();
 }
 
+/// ditto
+ListFilesRequest listFilesRequest(
+    string purpose,
+    size_t limit = ListFilesRequest.init.limit,
+    string order = ListFilesRequest.init.order,
+    string after = null)
+{
+    auto req = listFilesRequest();
+    req.purpose = purpose;
+    req.limit = limit;
+    req.order = order;
+    req.after = after;
+    return req;
+}
+
 /// Convenience constructor for `FileUploadRequest`.
 FileUploadRequest fileUploadRequest(string file, string purpose)
 {
@@ -116,6 +131,14 @@ unittest
 
     auto req = fileUploadRequest("input.jsonl", FilePurpose.FineTune);
     assert(serializeJson(req) == `{"file":"input.jsonl","purpose":"fine-tune"}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = listFilesRequest("assistants", 5, "asc", "f1");
+    assert(serializeJson(req) == `{"purpose":"assistants","limit":5,"order":"asc","after":"f1"}`);
 }
 
 unittest

--- a/source/openai/responses.d
+++ b/source/openai/responses.d
@@ -505,6 +505,24 @@ ListInputItemsRequest listInputItemsRequest(string responseId)
     return req;
 }
 
+/// ditto
+ListInputItemsRequest listInputItemsRequest(
+    string responseId,
+    size_t limit = ListInputItemsRequest.init.limit,
+    string order = ListInputItemsRequest.init.order,
+    string after = null,
+    string before = null,
+    Includable[] include = null)
+{
+    auto req = listInputItemsRequest(responseId);
+    req.limit = limit;
+    req.order = order;
+    req.after = after;
+    req.before = before;
+    req.include = include;
+    return req;
+}
+
 // -----------------------------------------------------------------------------
 // Response objects
 // -----------------------------------------------------------------------------
@@ -606,6 +624,14 @@ unittest
 
     auto req = createResponseRequest("gpt-4.1", CreateResponseInput("Hello"));
     assert(serializeJson(req) == `{"input":"Hello","model":"gpt-4.1"}`);
+}
+
+unittest
+{
+    import mir.ser.json : serializeJson;
+
+    auto req = listInputItemsRequest("resp1", 10, "desc", "a", "b");
+    assert(serializeJson(req) == `{"responseId":"resp1","limit":10,"order":"desc","after":"a","before":"b"}`);
 }
 
 unittest


### PR DESCRIPTION
## Summary
- overload list request helpers to set `after` and additional options
- update unit tests for the new helpers
- add a developer reflection

## Testing
- `dub run dfmt -- source`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_685729d767d8832ca50d6ab8e99b97ff