### PR TITLE
[clients] support bracketed array query params

### DIFF
--- a/.codex/reflections/2025-06-21-2232-query-params-array.md
+++ b/.codex/reflections/2025-06-21-2232-query-params-array.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-21 22:32]
+  - **Task**: Implement bracketed query parameter handling
+  - **Objective**: Allow QueryParamsBuilder to emit repeated keys when the key ends with []
+  - **Outcome**: Added feature with tests and documentation
+
+#### :sparkles: What went well
+  - Automated formatter and linter kept code consistent
+  - Coverage tools confirmed new tests hit all lines
+
+#### :warning: Pain points
+  - Remembering to clean example artifacts required an extra build step
+  - dfmt and dscanner downloads slowed down the workflow
+
+#### :bulb: Proposed Improvement
+  - Cache build tool binaries between runs to avoid repeated downloads

--- a/.codex/reflections/2025-06-21-2247-docs-array-guideline.md
+++ b/.codex/reflections/2025-06-21-2247-docs-array-guideline.md
@@ -1,0 +1,14 @@
+### :book: Reflection for [2025-06-21 22:47]
+  - **Task**: revise array parameter docs
+  - **Objective**: move new example from README to AGENTS per review comment
+  - **Outcome**: added guideline bullet in AGENTS and reverted README section
+
+#### :sparkles: What went well
+  - Formatter and linter finished without issues
+  - Tests and examples built successfully
+
+#### :warning: Pain points
+  - Large coverage outputs clutter the repository root
+
+#### :bulb: Proposed Improvement
+  - Store coverage files in a dedicated directory to keep the workspace clean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,7 @@ headers when modifying or archiving those files to maintain consistency.
 * Prefer `@serdeOptional` and `mir.algebraic.Nullable` for fields that may be omitted or null in API responses.
 * Apply `@serdeIgnoreUnexpectedKeys` and `@serdeOptional` to make deserialization resilient to future API changes.
 * When building URLs with array query parameters, use the correct bracketed syntax (e.g., `event_types[]`).
+* QueryParamsBuilder emits comma-separated values by default; append `[]` to the key to expand array elements individually.
 * Always use REST endpoints that include the relevant parent resource (e.g., projectId) for nested resources.
 * Add debug output for API failures to aid troubleshooting, like `debug scope(failure) { ... }`.
 * Write unittests using real-world API response samples to ensure robust deserialization.


### PR DESCRIPTION
## Summary
- clarify array query param usage in AGENTS.md
- remove README changes
- add reflection for docs update

## Testing
- `dub run dfmt -- source`
- `dub lint --dscanner-config dscanner.ini`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d core --clean`


------
https://chatgpt.com/codex/tasks/task_e_6857319ff148832caf73ae5eb3790517