### PR TITLE
[admin] simplify audit log url builder

### DIFF
--- a/.codex/reflections/2025-06-21-2257-simplify-audit-log-param-building.md
+++ b/.codex/reflections/2025-06-21-2257-simplify-audit-log-param-building.md
@@ -1,0 +1,15 @@
+### :book: Reflection for [2025-06-21 22:57]
+  - **Task**: Refactor buildListAuditLogsUrl
+  - **Objective**: Replace manual loops with QueryParamsBuilder's array support
+  - **Outcome**: Code simplified and tests still pass
+
+#### :sparkles: What went well
+  - Small change compiled quickly
+  - Existing tests ensured correctness
+
+#### :warning: Pain points
+  - Fetching dependencies for linting adds several seconds
+  - Coverage files clutter repository root
+
+#### :bulb: Proposed Improvement
+  - Cache dscanner and dfmt binaries between runs to avoid rebuilds

--- a/source/openai/clients/openai_admin.d
+++ b/source/openai/clients/openai_admin.d
@@ -37,26 +37,11 @@ class OpenAIAdminClient
     string buildListAuditLogsUrl(in ListAuditLogsRequest request) const @safe
     {
         auto b = QueryParamsBuilder(buildUrl("/organization/audit_logs"));
-        foreach (eventType; request.eventTypes)
-        {
-            b.add("event_types[]", eventType);
-        }
-        foreach (projectId; request.projectIds)
-        {
-            b.add("project_ids[]", projectId);
-        }
-        foreach (actorId; request.actorIds)
-        {
-            b.add("actor_ids[]", actorId);
-        }
-        foreach (actorEmail; request.actorEmails)
-        {
-            b.add("actor_emails[]", actorEmail);
-        }
-        foreach (resourceId; request.resourceIds)
-        {
-            b.add("resource_ids[]", resourceId);
-        }
+        b.add("event_types[]", request.eventTypes);
+        b.add("project_ids[]", request.projectIds);
+        b.add("actor_ids[]", request.actorIds);
+        b.add("actor_emails[]", request.actorEmails);
+        b.add("resource_ids[]", request.resourceIds);
         b.add("effective_at[gt]", request.effectiveAt.gt);
         b.add("effective_at[gte]", request.effectiveAt.gte);
         b.add("effective_at[lt]", request.effectiveAt.lt);


### PR DESCRIPTION
## Summary
- use QueryParamsBuilder array support in `buildListAuditLogsUrl`
- add reflection for this task

## Testing
- `dub test`
- `dub test --coverage --coverage-ctfe`


------
https://chatgpt.com/codex/tasks/task_e_685738424488832c9e7dde4af5dc4a06