### PR TITLE
Improve HTTP helper debug logs

### DIFF
--- a/.codex/reflections/2025-06-22-0053-request-helper-routines.md
+++ b/.codex/reflections/2025-06-22-0053-request-helper-routines.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-22 00:53]
+- **Task**: Create generic helper routines
+- **Objective**: Add reusable HTTP helpers
+- **Outcome**: Implemented makeHttp, getJson, postJson, deleteJson
+
+#### :sparkles: What went well
+- Code compiled and tests passed first try
+- New helpers reduce duplication potential
+
+#### :warning: Pain points
+- Understanding std.net.curl headers was tricky
+
+#### :bulb: Proposed Improvement
+- Document header retrieval for HTTP objects in std.net.curl
+
+#### :mortar_board: Learning & Insights
+- mixin templates can encapsulate private helpers
+- build_examples script generates artifacts needing cleanup
+
+#### :link: References
+- std.net.curl documentation

--- a/.codex/reflections/2025-06-22-0109-request-helpers-usage.md
+++ b/.codex/reflections/2025-06-22-0109-request-helpers-usage.md
@@ -1,0 +1,20 @@
+### :book: Reflection for [2025-06-22 01:09]
+- **Task**: Use helper methods for requests
+- **Objective**: Reduce boilerplate by applying new helper utilities
+- **Outcome**: Converted several request methods to use getJson, postJson, and deleteJson
+
+#### :sparkles: What went well
+- Helpers simplified HTTP setup
+- Formatter and tests succeeded
+
+#### :warning: Pain points
+- Updating every method manually was tedious
+
+#### :bulb: Proposed Improvement
+- Provide scripts to automate refactoring across multiple files
+
+#### :mortar_board: Learning & Insights
+- mixin templates can hide shared code effectively
+
+#### :link: References
+- dlang std.net.curl

--- a/.codex/reflections/2025-06-22-0133-debug-logging.md
+++ b/.codex/reflections/2025-06-22-0133-debug-logging.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-22 01:33]
+- **Task**: Apply diff comments and review debug logging
+- **Objective**: Honor feedback to improve helper routines
+- **Outcome**: Added debug output and corrected DELETE implementation
+
+#### :sparkles: What went well
+- Formatter, linter, and tests passed without issues
+- Helper methods now handle logging consistently
+
+#### :warning: Pain points
+- Cleaning up build artifacts after running examples is tedious
+
+#### :bulb: Proposed Improvement
+- Provide a script to purge temporary example artifacts
+
+#### :mortar_board: Learning & Insights
+- `debug scope (failure)` simplifies conditional debug logs
+- Using `HTTP.perform` respects custom callbacks like `onReceive`
+
+#### :link: References
+- std.net.curl documentation

--- a/.codex/reflections/2025-06-22-0153-debug-url-format.md
+++ b/.codex/reflections/2025-06-22-0153-debug-url-format.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-22 01:53]
+- **Task**: Apply diff comments and convert remaining methods
+- **Objective**: Ensure every request uses helper routines and logs the request URL
+- **Outcome**: Updated all admin client methods to rely on helpers and improved debug output
+
+#### :sparkles: What went well
+- The helper mixin simplified replacing repetitive HTTP setup
+- Formatter and tests caught no new issues after refactoring
+
+#### :warning: Pain points
+- Manual patching of many functions was tedious and error-prone
+
+#### :bulb: Proposed Improvement
+- Add script to rewrite functions using old HTTP patterns automatically
+
+#### :mortar_board: Learning & Insights
+- `debug scope(failure)` with URLs provides useful context when failures occur
+- Consolidating request logic helps maintain consistency across modules
+
+#### :link: References
+- std.net.curl documentation


### PR DESCRIPTION
## Summary
- log request URLs in helper debug output
- update all admin client methods to use the helper routines
- record a reflection on updating debug format

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d core`


------
https://chatgpt.com/codex/tasks/task_e_685752770948832c9d984334c5d60639