### PR TITLE
refactor: rename request/response structs for consistency

### DIFF
--- a/.codex/reflections/2025-06-22-0919-rename-structs.md
+++ b/.codex/reflections/2025-06-22-0919-rename-structs.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-22 09:19]
+- **Task**: Rename request/response structs
+- **Objective**: Ensure naming consistency across modules
+- **Outcome**: Updated structs, clients, tests, and examples; all checks pass
+
+#### :sparkles: What went well
+- Automated search-and-replace helped update references quickly
+- Formatter and linter ran without issues
+
+#### :warning: Pain points
+- Long build times when compiling examples slowed iteration
+
+#### :bulb: Proposed Improvement
+- Cache compiled example artifacts between builds to reduce waiting time
+
+#### :mortar_board: Learning & Insights
+- Consistent naming simplifies API usage and documentation
+- Running build scripts with `--clean` can remove lockfiles, so restore them before committing
+
+#### :link: References
+- openai library source and build scripts

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ import std.file : write;
 import openai;
 
 auto client = new OpenAIClient();
-auto up = fileUploadRequest("input.jsonl", FilePurpose.FineTune);
+auto up = uploadFileRequest("input.jsonl", FilePurpose.FineTune);
 auto uploaded = client.uploadFile(up);
 
 auto retrieved = client.retrieveFile(uploaded.id);

--- a/examples/files/source/app.d
+++ b/examples/files/source/app.d
@@ -6,7 +6,7 @@ import openai;
 void main()
 {
     auto client = new OpenAIClient();
-    auto req = fileUploadRequest("input.jsonl", FilePurpose.FineTune);
+    auto req = uploadFileRequest("input.jsonl", FilePurpose.FineTune);
     auto uploaded = client.uploadFile(req);
 
     auto list = client.listFiles(listFilesRequest());

--- a/source/openai/administration/admin_api_key.d
+++ b/source/openai/administration/admin_api_key.d
@@ -36,7 +36,7 @@ struct AdminApiKey
 }
 
 @serdeIgnoreUnexpectedKeys
-struct AdminApiKeyListResponse
+struct ListAdminApiKeyResponse
 {
     string object;
     AdminApiKey[] data;
@@ -93,7 +93,7 @@ unittest
     import mir.deser.json : deserializeJson;
 
     enum json = "{\"object\":\"list\",\"data\":[{\"object\":\"organization.admin_api_key\",\"id\":\"key_abc\",\"name\":\"Main Admin Key\",\"redacted_value\":\"sk-admin...def\",\"created_at\":1,\"last_used_at\":2}] ,\"first_id\":\"key_abc\",\"last_id\":\"key_abc\",\"has_more\":false}";
-    auto list = deserializeJson!AdminApiKeyListResponse(json);
+    auto list = deserializeJson!ListAdminApiKeyResponse(json);
     assert(list.data.length == 1);
     assert(list.data[0].id == "key_abc");
 }

--- a/source/openai/administration/invites.d
+++ b/source/openai/administration/invites.d
@@ -35,7 +35,7 @@ struct Invite
 }
 
 @serdeIgnoreUnexpectedKeys
-struct InviteListResponse
+struct ListInviteResponse
 {
     string object;
     Invite[] data;
@@ -45,7 +45,7 @@ struct InviteListResponse
 }
 
 @serdeIgnoreUnexpectedKeys
-struct InviteDeleteResponse
+struct DeleteInviteResponse
 {
     string object;
     string id;
@@ -96,7 +96,7 @@ unittest
     import mir.ser.json : serializeJson;
 
     enum example = `{"object":"list","data":[{"object":"organization.invite","id":"invite-abc","email":"user@example.com","role":"owner","status":"accepted","invited_at":1,"expires_at":2,"accepted_at":3}],"first_id":"invite-abc","last_id":"invite-abc","has_more":false}`;
-    auto list = deserializeJson!InviteListResponse(example);
+    auto list = deserializeJson!ListInviteResponse(example);
     assert(list.data.length == 1);
     assert(list.data[0].id == "invite-abc");
 
@@ -135,7 +135,7 @@ unittest
 }`;
     import mir.deser.json : deserializeJson;
 
-    auto list = deserializeJson!InviteListResponse(json);
+    auto list = deserializeJson!ListInviteResponse(json);
     assert(list.data.length == 1);
     assert(list.data[0].id == "invite-id");
     assert(list.data[0].email == "user@example.com");

--- a/source/openai/administration/project_api_keys.d
+++ b/source/openai/administration/project_api_keys.d
@@ -55,7 +55,7 @@ struct ProjectApiKey
 }
 
 @serdeIgnoreUnexpectedKeys
-struct ProjectApiKeyListResponse
+struct ListProjectApiKeyResponse
 {
     string object;
     ProjectApiKey[] data;
@@ -109,7 +109,7 @@ unittest
 
     enum example =
         `{"object":"list","data":[{"object":"organization.project.api_key","id":"key_abc","name":"Key","redacted_value":"sk-abc","created_at":1,"last_used_at":2,"owner":{"type":"user","id":"user_abc","name":"Owner"}}],"first_id":"key_abc","last_id":"key_abc","has_more":false}`;
-    auto list = deserializeJson!ProjectApiKeyListResponse(example);
+    auto list = deserializeJson!ListProjectApiKeyResponse(example);
     assert(list.data.length == 1);
     assert(list.data[0].id == "key_abc");
 }
@@ -198,7 +198,7 @@ unittest
 
     import mir.deser.json : deserializeJson;
 
-    auto list = deserializeJson!ProjectApiKeyListResponse(json);
+    auto list = deserializeJson!ListProjectApiKeyResponse(json);
     assert(list.data.length == 4);
     assert(list.data[0].id == "key_key1");
     assert(list.data[1].id == "key_key2");

--- a/source/openai/administration/project_rate_limits.d
+++ b/source/openai/administration/project_rate_limits.d
@@ -21,7 +21,7 @@ struct ProjectRateLimit
 }
 
 @serdeIgnoreUnexpectedKeys
-struct ProjectRateLimitListResponse
+struct ListProjectRateLimitResponse
 {
     string object;
     ProjectRateLimit[] data;
@@ -123,7 +123,7 @@ unittest
 
     enum listExample =
         `{"object":"list","data":[{"object":"organization.project.rate_limit","id":"rl_abc","max_requests_per_1_minute":10,"max_tokens_per_1_minute":100,"max_images_per_1_minute":5,"max_audio_megabytes_per_1_minute":20,"max_requests_per_1_day":50,"batch_1_day_max_input_tokens":1000}],"first_id":"rl_abc","last_id":"rl_abc","has_more":false}`;
-    auto list = deserializeJson!ProjectRateLimitListResponse(listExample);
+    auto list = deserializeJson!ListProjectRateLimitResponse(listExample);
     assert(list.data.length == 1);
     assert(list.data[0].id == "rl_abc");
 

--- a/source/openai/administration/project_service_accounts.d
+++ b/source/openai/administration/project_service_accounts.d
@@ -51,7 +51,7 @@ struct CreateProjectServiceAccountResponse
 }
 
 @serdeIgnoreUnexpectedKeys
-struct ProjectServiceAccountDeleteResponse
+struct DeleteProjectServiceAccountResponse
 {
     string object;
     string id;
@@ -59,7 +59,7 @@ struct ProjectServiceAccountDeleteResponse
 }
 
 @serdeIgnoreUnexpectedKeys
-struct ProjectServiceAccountListResponse
+struct ListProjectServiceAccountResponse
 {
     string object;
     ProjectServiceAccount[] data;
@@ -97,7 +97,7 @@ unittest
 
     enum listExample =
         `{"object":"list","data":[{"object":"organization.project.service_account","id":"svc_acct_abc","name":"Service Account","role":"owner","created_at":1711471533}],"first_id":"svc_acct_abc","last_id":"svc_acct_xyz","has_more":false}`;
-    auto list = deserializeJson!ProjectServiceAccountListResponse(listExample);
+    auto list = deserializeJson!ListProjectServiceAccountResponse(listExample);
     assert(list.data.length == 1);
     assert(list.data[0].name == "Service Account");
 
@@ -108,7 +108,7 @@ unittest
 
     enum delExample =
         `{"object":"organization.project.service_account.deleted","id":"svc_acct_abc","deleted":true}`;
-    auto del = deserializeJson!ProjectServiceAccountDeleteResponse(delExample);
+    auto del = deserializeJson!DeleteProjectServiceAccountResponse(delExample);
     assert(del.deleted);
 
     auto lreq = listProjectServiceAccountsRequest(5);

--- a/source/openai/administration/projects.d
+++ b/source/openai/administration/projects.d
@@ -19,7 +19,7 @@ struct Project
 }
 
 @serdeIgnoreUnexpectedKeys
-struct ProjectListResponse
+struct ListProjectResponse
 {
     string object;
     Project[] data;

--- a/source/openai/administration/usage.d
+++ b/source/openai/administration/usage.d
@@ -144,7 +144,7 @@ struct UsageTimeBucket
 }
 
 @serdeIgnoreUnexpectedKeys
-struct UsageResponse
+struct ListUsageResponse
 {
     string object;
     UsageTimeBucket[] data;
@@ -162,7 +162,7 @@ struct CostsTimeBucket
 }
 
 @serdeIgnoreUnexpectedKeys
-struct CostsResponse
+struct ListCostsResponse
 {
     string object;
     CostsTimeBucket[] data;
@@ -257,7 +257,7 @@ unittest
     import mir.deser.json : deserializeJson;
 
     enum example = `{"object":"page","data":[{"object":"bucket","start_time":1730419200,"end_time":1730505600,"results":[{"object":"organization.usage.audio_speeches.result","characters":45,"num_model_requests":1,"project_id":null,"user_id":null,"api_key_id":null,"model":null}]}],"has_more":false,"next_page":null}`;
-    auto res = deserializeJson!UsageResponse(example);
+    auto res = deserializeJson!ListUsageResponse(example);
     assert(res.data.length == 1);
     assert(res.data[0].results.length == 1);
     assert(res.data[0].results[0].get!UsageAudioSpeechesResult().characters == 45);
@@ -268,7 +268,7 @@ unittest
     import mir.deser.json : deserializeJson;
 
     enum example = `{"object":"page","data":[{"object":"bucket","start_time":1730419200,"end_time":1730505600,"results":[{"object":"organization.costs.result","amount":{"value":0.06,"currency":"usd"},"line_item":null,"project_id":null}]}],"has_more":false,"next_page":null}`;
-    auto res = deserializeJson!CostsResponse(example);
+    auto res = deserializeJson!ListCostsResponse(example);
     assert(res.data[0].results[0].amount.value == 0.06);
 }
 
@@ -295,7 +295,7 @@ unittest
 }`;
     import mir.deser.json : deserializeJson;
 
-    auto res = deserializeJson!UsageResponse(json);
+    auto res = deserializeJson!ListUsageResponse(json);
     assert(res.data.length == 2);
     assert(res.data[0].startTime == 1_750_420_300);
     assert(res.data[0].endTime == 1_750_464_000);
@@ -342,7 +342,7 @@ unittest
 }`;
     import mir.deser.json : deserializeJson;
 
-    auto res = deserializeJson!UsageResponse(json);
+    auto res = deserializeJson!ListUsageResponse(json);
     assert(res.data.length == 2);
     assert(res.data[0].startTime == 1_750_420_976);
     assert(res.data[0].endTime == 1_750_464_000);

--- a/source/openai/administration/users.d
+++ b/source/openai/administration/users.d
@@ -25,7 +25,7 @@ struct ProjectUser
 }
 
 @serdeIgnoreUnexpectedKeys
-struct ProjectUserListResponse
+struct ListProjectUserResponse
 {
     string object;
     ProjectUser[] data;
@@ -82,7 +82,7 @@ struct User
 }
 
 @serdeIgnoreUnexpectedKeys
-struct UserListResponse
+struct ListUserResponse
 {
     string object;
     User[] data;
@@ -92,7 +92,7 @@ struct UserListResponse
 }
 
 @serdeIgnoreUnexpectedKeys
-struct UserDeleteResponse
+struct DeleteUserResponse
 {
     string object;
     string id;
@@ -162,7 +162,7 @@ unittest
 
     enum example =
         `{"object":"list","data":[{"object":"organization.user","id":"user-1","name":"Alice","email":"a@example.com","role":"owner","added_at":1}],"first_id":"user-1","last_id":"user-1","has_more":false}`;
-    auto list = deserializeJson!UserListResponse(example);
+    auto list = deserializeJson!ListUserResponse(example);
     assert(list.data.length == 1);
     assert(list.data[0].name == "Alice");
 }
@@ -186,7 +186,7 @@ unittest
 
     enum listExample =
         `{"object":"list","data":[{"object":"organization.project.user","id":"user_abc","name":"First Last","email":"user@example.com","role":"owner","added_at":1}],"first_id":"user_abc","last_id":"user_abc","has_more":false}`;
-    auto list = deserializeJson!ProjectUserListResponse(listExample);
+    auto list = deserializeJson!ListProjectUserResponse(listExample);
     assert(list.data.length == 1);
     assert(list.data[0].email == "user@example.com");
 

--- a/source/openai/clients/openai.d
+++ b/source/openai/clients/openai.d
@@ -91,11 +91,11 @@ class OpenAIClient
 
     /// Retrieve the list of models available to the API key by
     /// issuing a GET request to `/models`.
-    ModelsResponse listModels() @system
+    ListModelResponse listModels() @system
     in (config.apiKey != null && config.apiKey.length > 0)
     do
     {
-        return getJson!ModelsResponse("/models");
+        return getJson!ListModelResponse("/models");
     }
 
     /// Call the `/completions` endpoint.
@@ -297,14 +297,14 @@ class OpenAIClient
     }
 
     /// List uploaded files.
-    FileListResponse listFiles(in ListFilesRequest request) @system
+    ListFileResponse listFiles(in ListFilesRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!FileListResponse(buildListFilesUrl(request));
+        return getJson!ListFileResponse(buildListFilesUrl(request));
     }
 
     /// Upload a file.
-    FileObject uploadFile(in FileUploadRequest request) @system
+    FileObject uploadFile(in UploadFileRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (request.file.length > 0)
     in (request.purpose.length > 0)
@@ -372,11 +372,11 @@ class OpenAIClient
     }
 
     ///
-    ResponsesItemListResponse listInputItems(in ListInputItemsRequest request) @system
+    ListResponsesItemResponse listInputItems(in ListInputItemsRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (request.responseId.length > 0)
     {
-        return getJson!ResponsesItemListResponse(buildListInputItemsUrl(request));
+        return getJson!ListResponsesItemResponse(buildListInputItemsUrl(request));
     }
 
     @("buildUrl variations")

--- a/source/openai/clients/openai_admin.d
+++ b/source/openai/clients/openai_admin.d
@@ -155,10 +155,10 @@ private:
 
 public:
     /// List organization and project admin API keys.
-    AdminApiKeyListResponse listAdminApiKeys(in ListAdminApiKeysRequest request) @system
+    ListAdminApiKeyResponse listAdminApiKeys(in ListAdminApiKeysRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!AdminApiKeyListResponse(buildListAdminApiKeysUrl(request));
+        return getJson!ListAdminApiKeyResponse(buildListAdminApiKeysUrl(request));
     }
 
     /// Create an admin API key.
@@ -185,10 +185,10 @@ public:
     }
 
     /// List invites for the organization.
-    InviteListResponse listInvites(in ListInvitesRequest request) @system
+    ListInviteResponse listInvites(in ListInvitesRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!InviteListResponse(buildListInvitesUrl(request));
+        return getJson!ListInviteResponse(buildListInvitesUrl(request));
     }
 
     /// Create an invite.
@@ -207,18 +207,18 @@ public:
     }
 
     /// Delete an invite.
-    InviteDeleteResponse deleteInvite(string inviteId) @system
+    DeleteInviteResponse deleteInvite(string inviteId) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (inviteId.length > 0)
     {
-        return deleteJson!InviteDeleteResponse("/organization/invites/" ~ inviteId);
+        return deleteJson!DeleteInviteResponse("/organization/invites/" ~ inviteId);
     }
 
     /// List users.
-    UserListResponse listUsers(in ListUsersRequest request) @system
+    ListUserResponse listUsers(in ListUsersRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UserListResponse(buildListUsersUrl(request));
+        return getJson!ListUserResponse(buildListUsersUrl(request));
     }
 
     /// Retrieve a user by ID.
@@ -238,11 +238,11 @@ public:
     }
 
     /// Delete a user.
-    UserDeleteResponse deleteUser(string userId) @system
+    DeleteUserResponse deleteUser(string userId) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (userId.length > 0)
     {
-        return deleteJson!UserDeleteResponse("/organization/users/" ~ userId);
+        return deleteJson!DeleteUserResponse("/organization/users/" ~ userId);
     }
 
     /// List audit logs for the organization.
@@ -253,10 +253,10 @@ public:
     }
 
     /// List projects.
-    ProjectListResponse listProjects(in ListProjectsRequest request) @system
+    ListProjectResponse listProjects(in ListProjectsRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!ProjectListResponse(buildListProjectsUrl(request));
+        return getJson!ListProjectResponse(buildListProjectsUrl(request));
     }
 
     /// Create a project.
@@ -291,11 +291,11 @@ public:
     }
 
     /// List users in a project.
-    ProjectUserListResponse listProjectUsers(string projectId, in ListProjectUsersRequest request) @system
+    ListProjectUserResponse listProjectUsers(string projectId, in ListProjectUsersRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (projectId.length > 0)
     {
-        return getJson!ProjectUserListResponse(buildListProjectUsersUrl(projectId, request));
+        return getJson!ListProjectUserResponse(buildListProjectUsersUrl(projectId, request));
     }
 
     /// Add a user to a project.
@@ -334,11 +334,11 @@ public:
     }
 
     /// List service accounts for a project.
-    ProjectServiceAccountListResponse listProjectServiceAccounts(string projectId, in ListProjectServiceAccountsRequest request) @system
+    ListProjectServiceAccountResponse listProjectServiceAccounts(string projectId, in ListProjectServiceAccountsRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (projectId.length > 0)
     {
-        return getJson!ProjectServiceAccountListResponse(buildListProjectServiceAccountsUrl(projectId, request));
+        return getJson!ListProjectServiceAccountResponse(buildListProjectServiceAccountsUrl(projectId, request));
     }
 
     /// Create a project service account.
@@ -361,21 +361,21 @@ public:
     }
 
     /// Delete a project service account.
-    ProjectServiceAccountDeleteResponse deleteProjectServiceAccount(string projectId, string serviceAccountId) @system
+    DeleteProjectServiceAccountResponse deleteProjectServiceAccount(string projectId, string serviceAccountId) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (projectId.length > 0)
     in (serviceAccountId.length > 0)
     {
-        return deleteJson!ProjectServiceAccountDeleteResponse(
+        return deleteJson!DeleteProjectServiceAccountResponse(
             "/organization/projects/" ~ projectId ~ "/service_accounts/" ~ serviceAccountId);
     }
 
     /// List API keys for a project.
-    ProjectApiKeyListResponse listProjectApiKeys(string projectId, in ListProjectApiKeysRequest request) @system
+    ListProjectApiKeyResponse listProjectApiKeys(string projectId, in ListProjectApiKeysRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (projectId.length > 0)
     {
-        return getJson!ProjectApiKeyListResponse(buildListProjectApiKeysUrl(projectId, request));
+        return getJson!ListProjectApiKeyResponse(buildListProjectApiKeysUrl(projectId, request));
     }
 
     /// Retrieve a project API key by ID.
@@ -395,11 +395,11 @@ public:
     }
 
     /// List rate limits for a project.
-    ProjectRateLimitListResponse listProjectRateLimits(string projectId, in ListProjectRateLimitsRequest request) @system
+    ListProjectRateLimitResponse listProjectRateLimits(string projectId, in ListProjectRateLimitsRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     in (projectId.length > 0)
     {
-        return getJson!ProjectRateLimitListResponse(
+        return getJson!ListProjectRateLimitResponse(
             buildListProjectRateLimitsUrl(projectId, request));
     }
 
@@ -449,66 +449,66 @@ public:
     }
 
     /// List cost reports for the organization.
-    CostsResponse listCosts(in ListCostsRequest request) @system
+    ListCostsResponse listCosts(in ListCostsRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!CostsResponse(buildListCostsUrl(request));
+        return getJson!ListCostsResponse(buildListCostsUrl(request));
     }
 
     /// List usage reports for a specific type.
-    UsageResponse listUsageCompletions(in ListUsageRequest request) @system
+    ListUsageResponse listUsageCompletions(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("completions", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("completions", request));
     }
 
     ///
-    UsageResponse listUsageEmbeddings(in ListUsageRequest request) @system
+    ListUsageResponse listUsageEmbeddings(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("embeddings", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("embeddings", request));
     }
 
     ///
-    UsageResponse listUsageImages(in ListUsageRequest request) @system
+    ListUsageResponse listUsageImages(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("images", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("images", request));
     }
 
     ///
-    UsageResponse listUsageModerations(in ListUsageRequest request) @system
+    ListUsageResponse listUsageModerations(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("moderations", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("moderations", request));
     }
 
     ///
-    UsageResponse listUsageAudioSpeeches(in ListUsageRequest request) @system
+    ListUsageResponse listUsageAudioSpeeches(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("audio_speeches", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("audio_speeches", request));
     }
 
     ///
-    UsageResponse listUsageAudioTranscriptions(in ListUsageRequest request) @system
+    ListUsageResponse listUsageAudioTranscriptions(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("audio_transcriptions", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("audio_transcriptions", request));
     }
 
     ///
-    UsageResponse listUsageVectorStores(in ListUsageRequest request) @system
+    ListUsageResponse listUsageVectorStores(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("vector_stores", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("vector_stores", request));
     }
 
     ///
-    UsageResponse listUsageCodeInterpreterSessions(in ListUsageRequest request) @system
+    ListUsageResponse listUsageCodeInterpreterSessions(in ListUsageRequest request) @system
     in (config.apiKey != null && config.apiKey.length > 0)
     {
-        return getJson!UsageResponse(buildListUsageUrl("code_interpreter_sessions", request));
+        return getJson!ListUsageResponse(buildListUsageUrl("code_interpreter_sessions", request));
     }
 }
 

--- a/source/openai/files.d
+++ b/source/openai/files.d
@@ -41,7 +41,7 @@ enum FilePurpose : string
 // Requests
 // -----------------------------------------------------------------------------
 
-struct FileUploadRequest
+struct UploadFileRequest
 {
     string file;
     string purpose;
@@ -76,10 +76,10 @@ ListFilesRequest listFilesRequest(
     return req;
 }
 
-/// Convenience constructor for `FileUploadRequest`.
-FileUploadRequest fileUploadRequest(string file, string purpose)
+/// Convenience constructor for `UploadFileRequest`.
+UploadFileRequest uploadFileRequest(string file, string purpose)
 {
-    auto req = FileUploadRequest();
+    auto req = UploadFileRequest();
     req.file = file;
     req.purpose = purpose;
     return req;
@@ -104,7 +104,7 @@ struct FileObject
 }
 
 @serdeIgnoreUnexpectedKeys
-struct FileListResponse
+struct ListFileResponse
 {
     string object;
     FileObject[] data;
@@ -129,7 +129,7 @@ unittest
 {
     import mir.ser.json : serializeJson;
 
-    auto req = fileUploadRequest("input.jsonl", FilePurpose.FineTune);
+    auto req = uploadFileRequest("input.jsonl", FilePurpose.FineTune);
     assert(serializeJson(req) == `{"file":"input.jsonl","purpose":"fine-tune"}`);
 }
 
@@ -160,7 +160,7 @@ unittest
     import mir.deser.json : deserializeJson;
 
     enum json = `{"object":"list","data":[{"id":"file-1","object":"file","bytes":1,"created_at":1,"filename":"f.txt","purpose":"assistants","status":"processed"}],"first_id":"file-1","last_id":"file-1","has_more":false}`;
-    auto list = deserializeJson!FileListResponse(json);
+    auto list = deserializeJson!ListFileResponse(json);
     assert(list.data.length == 1);
     assert(list.firstId == "file-1");
     assert(!list.hasMore);

--- a/source/openai/models.d
+++ b/source/openai/models.d
@@ -186,7 +186,7 @@ struct Model
 }
 
 ///
-struct ModelsResponse
+struct ListModelResponse
 {
     ///
     Model[] data;
@@ -199,7 +199,7 @@ unittest
     import mir.deser.json;
 
     const json = `{"object":"list","data":[{"id":"gpt-3.5-turbo","created":0,"object":"model","owned_by":"openai"}]}`;
-    auto response = deserializeJson!ModelsResponse(json);
+    auto response = deserializeJson!ListModelResponse(json);
 
     assert(response.object == "list");
     assert(response.data.length == 1);

--- a/source/openai/responses.d
+++ b/source/openai/responses.d
@@ -599,7 +599,7 @@ struct ResponsesResponse
 }
 
 @serdeIgnoreUnexpectedKeys
-struct ResponsesItemListResponse
+struct ListResponsesItemResponse
 {
     /// Resource type.
     string object;
@@ -640,7 +640,7 @@ unittest
 
     enum json = "{\"object\":\"list\",\"data\":[],\"first_id\":null,\"last_id\":null,\"has_more\":false}";
 
-    auto list = deserializeJson!ResponsesItemListResponse(json);
+    auto list = deserializeJson!ListResponsesItemResponse(json);
     assert(!list.hasMore);
 }
 
@@ -869,7 +869,7 @@ unittest
   "has_more": false,
   "last_id": "msg_202020202020202020202020202020202020202020202020"
 }`;
-    auto list = deserializeJson!ResponsesItemListResponse(json);
+    auto list = deserializeJson!ListResponsesItemResponse(json);
     assert(list.data.length == 1);
     assert(list.data[0].content[0].get!ResponsesInputTextContent().text == "Hello!");
     assert(!list.hasMore);


### PR DESCRIPTION
## Summary
- rename various response structs and file upload helper
- update OpenAI clients to use new request/response names
- adjust unit tests, examples and docs
- run formatter, linter, tests and example builds
- add project reflection

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d core administration --clean`


------
https://chatgpt.com/codex/tasks/task_e_6857c84086b4832ca0ebe549d951d368