### PR TITLE
Add changelog for v0.9.0

### DIFF
--- a/.codex/reflections/2025-06-22-1127-changelog-v0.9.0.md
+++ b/.codex/reflections/2025-06-22-1127-changelog-v0.9.0.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-22 11:27]
+  - **Task**: Write CHANGELOG for v0.9.0
+  - **Objective**: Document major changes since v0.8.0
+  - **Outcome**: Added CHANGELOG.md summarizing new features and improvements
+
+#### :sparkles: What went well
+  - Quickly gathered commit history using Git
+  - Summarized key enhancements without reading every commit
+
+#### :warning: Pain points
+  - Large number of commits made it hard to pinpoint highlights
+
+#### :bulb: Proposed Improvement
+  - Provide concise release notes or milestones to simplify changelog creation
+
+#### :mortar_board: Learning & Insights
+  - `git log` with ranges is useful for summarizing changes
+  - Running dfmt, linter, and tests ensures documentation updates don’t break CI
+
+#### :page_facing_up: Reference Info
+  - [AGENTS.md instructions for formatting and tests](../AGENTS.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [v0.9.0] - 2025-06-22
+### Added
+- Added `OpenAIAdminClient` with comprehensive administration modules (projects, API keys, invites, users, service accounts, rate limits, certificates, audit logs, usage).
+- Introduced `Responses` and `Images` API implementations.
+- Implemented `QueryParamsBuilder` helper for assembling query strings.
+- Added `validate` method and environment-based creation in `OpenAIClientConfig`.
+- Numerous example programs demonstrating new features.
+- Integrated Codecov and improved CI caching of Dub packages.
+
+### Changed
+- Switched optional fields to `mir.algebraic.Nullable`.
+- Standardized request and response structure names.
+- Refactored URL helpers and removed redundant client functions.
+
+### Fixed
+- Corrected numeric literal style and CI paths.
+- Miscellaneous bug fixes and test refinements.
+


### PR DESCRIPTION
## Summary
- document changes since v0.8.0 in `CHANGELOG.md`
- add reflection about creating the changelog

## Testing
- `dub run dfmt -- source examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6857e77fb368832ca998f3e687c3771f