### PR TITLE
Update audit logs example with project filter

### DIFF
--- a/.codex/reflections/2025-06-23-0134-audit-project-id.md
+++ b/.codex/reflections/2025-06-23-0134-audit-project-id.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-23 01:34]
+  - **Task**: update audit logs example with project ID filter
+  - **Objective**: demonstrate filtering audit logs by project ID and event type
+  - **Outcome**: example builds and tests pass
+
+#### :sparkles: What went well
+  - Clear AGENTS instructions guided the build steps
+  - Formatter and linter ran without issues after installing tools
+
+#### :warning: Pain points
+  - Building example groups with underscores required using the `all` mode, not `core`, which initially caused a mismatch
+
+#### :bulb: Proposed Improvement
+  - Document the difference between `core` and `all` modes in the build script help output
+
+#### :mortar_board: Learning & Insights
+  - The build script excludes underscored directories in `core` mode
+  - Example builds rely on `dub build` in each directory
+
+#### :link: References
+  - `scripts/build_examples.d`

--- a/examples/administration_audit_logs/source/app.d
+++ b/examples/administration_audit_logs/source/app.d
@@ -1,12 +1,19 @@
-import std.stdio;
+import std;
 
 import openai;
 
 void main()
 {
     auto client = new OpenAIAdminClient();
-    // Filter audit logs by event type
-    auto request = listAuditLogsRequest(20, null, ["api_key.created", "api_key.deleted"]);
+    // Fetch projects to find the ID of "Example Project"
+    auto projects = client.listProjects(listProjectsRequest(20));
+    auto targetProject = projects.data.filter!(p => p.name == "Example Project").front;
+    auto projectId = targetProject.id;
+
+    // Filter audit logs by project ID and event type
+    auto request = listAuditLogsRequest(20, [projectId], [
+        "api_key.created", "api_key.deleted"
+    ]);
     auto logs = client.listAuditLogs(request);
     writeln(logs.data);
 }


### PR DESCRIPTION
## Summary
- filter admin audit logs by project ID in administration_audit_logs example
- add reflection about building underscored examples

## Testing
- `dub run dfmt -- examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d all administration_audit_logs`


------
https://chatgpt.com/codex/tasks/task_e_6858ade0505c832c8938943f1fb5e08e