### PR TITLE
Add key unit tests for new helpers and models

### DIFF
--- a/.codex/reflections/2025-06-23-0825-add-tests.md
+++ b/.codex/reflections/2025-06-23-0825-add-tests.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-23 08:25]
+  - **Task**: implement unit tests
+  - **Objective**: increase coverage for new helpers and models
+  - **Outcome**: added tests and verified formatter, linter, examples
+
+#### :sparkles: What went well
+  - dfmt and lint ran without issues
+  - coverage shows helper file fully covered
+
+#### :warning: Pain points
+  - QueryParamsBuilder had no failing scenarios so error case was less meaningful
+
+#### :bulb: Proposed Improvement
+  - Expand QueryParamsBuilder with validation to allow real error tests
+
+#### :mortar_board: Learning & Insights
+  - Example build script touches many directories in core mode
+  - `mir.serde` gracefully ignores unknown JSON fields
+
+#### :link: References
+  - `source/openai/clients/helpers.d`

--- a/source/openai/clients/config.d
+++ b/source/openai/clients/config.d
@@ -197,3 +197,30 @@ class OpenAIClientConfig
         write(filePath, serializeJson(this));
     }
 }
+
+@("validate - openai mode")
+unittest
+{
+    auto cfg = new OpenAIClientConfig("k");
+    cfg.validate();
+}
+
+@("validate - azure mode")
+unittest
+{
+    auto cfg = new OpenAIClientConfig("k");
+    cfg.apiBase = "https://ex.api.cognitive.microsoft.com";
+    cfg.deploymentId = "dep";
+    cfg.validate();
+}
+
+@("validate - azure missing deployment")
+unittest
+{
+    import std.exception : assertThrown;
+
+    auto cfg = new OpenAIClientConfig("k");
+    cfg.apiBase = "https://ex.api.cognitive.microsoft.com";
+    cfg.deploymentId = "";
+    assertThrown!Exception(cfg.validate());
+}

--- a/source/openai/clients/helpers.d
+++ b/source/openai/clients/helpers.d
@@ -112,6 +112,38 @@ unittest
     assert(b.finish() == "https://example.com?ids[]=foo%20bar&ids[]=baz");
 }
 
+@("QueryParamsBuilder finish with multiple types")
+unittest
+{
+    auto b = QueryParamsBuilder("https://api.test");
+    b.add("q", "hello world");
+    b.add("flag", true);
+    b.add("page", 2);
+    assert(b.finish() == "https://api.test?q=hello%20world&flag=true&page=2");
+}
+
+@("QueryParamsBuilder ignores empty values")
+unittest
+{
+    string[] ids;
+    auto b = QueryParamsBuilder("https://api.test");
+    b.add("q", "");
+    b.add("flag", false);
+    b.add("page", 0);
+    b.add("ids", ids);
+    assert(b.finish() == "https://api.test");
+}
+
+@("QueryParamsBuilder negative integer")
+unittest
+{
+    auto b = QueryParamsBuilder("https://api.test");
+    b.add("offset", -5);
+    import std.algorithm.searching : endsWith;
+
+    assert(b.finish().endsWith("offset=-5"));
+}
+
 @system struct MultipartPart
 {
     string name;

--- a/source/openai/images.d
+++ b/source/openai/images.d
@@ -173,3 +173,32 @@ unittest
     assert(res.data.length == 1);
     assert(res.data[0].b64Json == "aa");
 }
+
+@("ImageResponse fromJson with url")
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    const json = `{"created":1,"data":[{"url":"https://img"}]}`;
+    auto res = deserializeJson!ImageResponse(json);
+    assert(res.data[0].url == "https://img");
+}
+
+@("ImageResponse with revised prompt")
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    const json = `{"created":1,"data":[{"revised_prompt":"ok"}]}`;
+    auto res = deserializeJson!ImageResponse(json);
+    assert(res.data[0].revisedPrompt == "ok");
+}
+
+@("ImageResponse missing data throws")
+unittest
+{
+    import std.exception : assertThrown;
+    import mir.deser.json : deserializeJson;
+
+    assertThrown!Exception(deserializeJson!ImageResponse(`{"created":1}`));
+}

--- a/source/openai/responses.d
+++ b/source/openai/responses.d
@@ -1003,3 +1003,36 @@ unittest
     auto jsonString = serializeJson(tool);
     assert(jsonString == `{"type":"local_shell"}`);
 }
+
+@("ResponsesResponse fromJson normal")
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    enum json = `{"id":"res_1","object":"response","created_at":1,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4","output":[],"parallel_tool_calls":false,"previous_response_id":null,"reasoning":{},"store":true,"temperature":0.2,"text":{"format":{"type":"text"}},"tool_choice":"none","tools":[],"top_p":1.0,"truncation":"none","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2},"user":null,"metadata":null}`;
+    auto res = deserializeJson!ResponsesResponse(json);
+    assert(res.id == "res_1");
+    assert(res.output.length == 0);
+    assert(res.text.format.type == TextResponseFormatType.Text);
+}
+
+@("ResponsesResponse ignores extra fields")
+unittest
+{
+    import mir.deser.json : deserializeJson;
+
+    enum json = `{"id":"res_1","object":"response","created_at":1,"status":"completed","model":"gpt-4","output":[],"parallel_tool_calls":false,"reasoning":{},"store":true,"temperature":0.0,"text":{"format":{"type":"text"}},"tool_choice":"none","tools":[],"top_p":1.0,"truncation":"none","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2},"extra":"x"}`;
+    auto res = deserializeJson!ResponsesResponse(json);
+    assert(res.id == "res_1");
+    assert(res.temperature == 0.0);
+}
+
+@("ResponsesResponse missing required field throws")
+unittest
+{
+    import std.exception : assertThrown;
+    import mir.deser.json : deserializeJson;
+
+    enum json = `{"object":"response"}`; // missing many fields
+    assertThrown!Exception(deserializeJson!ResponsesResponse(json));
+}


### PR DESCRIPTION
## Summary
- add QueryParamsBuilder finish tests
- cover OpenAIClientConfig.validate scenarios
- add fromJson tests for ResponsesResponse and ImageResponse
- document testing reflection

## Testing
- `dub run dfmt -- source`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d core`


------
https://chatgpt.com/codex/tasks/task_e_685906e1bde0832c8a76fda9e5d0424d