### PR TITLE
Improve design docs workflow

### DIFF
--- a/.codex/reflections/2025-06-28-0250-update-design-guidelines.md
+++ b/.codex/reflections/2025-06-28-0250-update-design-guidelines.md
@@ -1,0 +1,22 @@
+### :book: Reflection for [2025-06-28 02:50]
+  - **Task**: Improve AGENT docs for design workflow
+  - **Objective**: Prevent implementation before proposals and ADRs are finalized
+  - **Outcome**: Added explicit gating rules in AGENTS.md and docs/design/AGENT.md
+
+#### :sparkles: What went well
+  - Sed patching allowed quick insertion of new section headings
+  - Root guidelines clarified that tests were unnecessary for doc-only changes
+
+#### :warning: Pain points
+  - Inserting multi-line text with sed was error prone and required multiple attempts
+  - Lost a closing paragraph during edits and had to recover from git
+
+#### :bulb: Proposed Improvement
+  - Provide helper scripts for appending or inserting Markdown snippets to avoid formatting mistakes
+
+#### :mortar_board: Learning & Insights
+  - Use `git show HEAD:file` to recover original content when a patch goes wrong
+  - Always check for trailing blank lines after sed insertions
+
+#### :link: References
+  - `.codex/reflection-template.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@
 
 * Follow `docs/design/AGENT.md` when drafting or updating proposals or ADRs.
 * Tests and linter are not required if you only change design documents.
+* Complete and approve the proposal or ADR **before** starting implementation to avoid plan/code divergence.
 
 ### Implementation Phase
 

--- a/docs/design/AGENT.md
+++ b/docs/design/AGENT.md
@@ -105,10 +105,11 @@ Adopt PostgreSQL 14 for OLTP workloads.
 1. **Draft Proposal** in `docs/design/proposals/`.
 2. **Review & Iterate** with stakeholders; update `status` to `Under Review`.
 3. On **approval**, change `status` to `Approved` and tag the PR.
-4. **Implementation**: link PR to Proposal (e.g., “Implements Proposal 0001”).
+4. **Implementation** may begin *only after* the Proposal is `Approved` and any required ADR is `Accepted`. Link the PR to the document (e.g., “Implements Proposal 0001”).
 5. When an architectural decision is needed as a result, **create ADR** in `docs/design/adr/`, referencing the Proposal.
 6. **Review ADR** with architecture team; update `status` to `Accepted`.
 7. Tag implementation PRs with `This change implements ADR-XXXX`.
+8. Never start coding while the Proposal or ADR is still in `Draft` or `Under Review`.
 
 ---
 
@@ -156,6 +157,14 @@ Adopt PostgreSQL 14 for OLTP workloads.
 * Regularly audit `docs/adr/` for deprecated entries.
 * Use cross‑references to maintain a clear history of decisions.
 
+## 9. Implementation Discipline
+
+To avoid a mismatch between planned work and committed code:
+
+* Finish drafting your Proposal or ADR before writing any implementation code.
+* Wait until its `status` is `Approved` (Proposal) or `Accepted` (ADR) prior to opening implementation PRs.
+* Implementation PRs referencing drafts will be rejected to prevent wasted effort.
+* Skipping these steps risks delivering features that no longer match the agreed design.
 ---
 
 *By following this structure and workflow, teams can ensure transparent decision‑making, easy onboarding for new members, and a traceable evolution of both features and architecture.*


### PR DESCRIPTION
## Summary
- clarify that proposals/ADRs must be finished and approved before coding
- stress the rule in docs/design/AGENT workflow
- document the policy in the root AGENTS guide
- add reflection on updating design guidelines

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_685f57a410d4832c84afbcefec75b595