### PR TITLE
Add chat file message helper

### DIFF
--- a/.codex/reflections/2025-06-28-0209-chat-file-proposal.md
+++ b/.codex/reflections/2025-06-28-0209-chat-file-proposal.md
@@ -1,0 +1,22 @@
+### :book: Reflection for [2025-06-28 02:09]
+  - **Task**: Draft proposal for chat file messages
+  - **Objective**: Explain how to support file attachments in Chat Completion messages
+  - **Outcome**: Created design document and updated index
+
+#### :sparkles: What went well
+  - Repository already had clear templates for proposals
+  - Writing the solution sketch was straightforward after examining current chat message structs
+
+#### :warning: Pain points
+  - Remembering to update the proposal index manually could be error prone
+
+#### :bulb: Proposed Improvement
+  - Add a script that automatically updates `INDEX.md` when new proposals are added
+
+#### :mortar_board: Learning & Insights
+  - The chat module only supports text and image message types currently
+  - Reviewing the Python sample clarified the needed structure for file messages
+
+#### :link: References
+  - docs/design/AGENT.md
+  - README snippet demonstrating Files API usage

--- a/.codex/reflections/2025-06-28-0230-chat-file-helper.md
+++ b/.codex/reflections/2025-06-28-0230-chat-file-helper.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-28 02:30]
+  - **Task**: Implement chat file message helper
+  - **Objective**: Add `userChatMessageWithFile` and update changelog
+  - **Outcome**: Created new struct and helper, updated tests and docs
+
+#### :sparkles: What went well
+  - dfmt and linter caught no style issues
+  - Running coverage ensured new tests executed
+
+#### :warning: Pain points
+  - Setting up a temporary dub project to inspect serialization was cumbersome
+
+#### :bulb: Proposed Improvement
+  - Provide a small script for quickly compiling sample code with local dependencies
+
+#### :mortar_board: Learning & Insights
+  - `ChatUserMessageFileContent` requires a nested struct to match OpenAI JSON
+  - Example builds use `all` mode when directories contain underscores
+
+#### :link: References
+  - docs/design/proposals/0002-chat-file-message.md

--- a/.codex/reflections/2025-06-28-0314-update-proposal.md
+++ b/.codex/reflections/2025-06-28-0314-update-proposal.md
@@ -1,0 +1,22 @@
+### :book: Reflection for [2025-06-28 03:14]
+  - **Task**: Update proposal and changelog after file message implementation
+  - **Objective**: Align documentation with the new chat file feature and finalize version notes
+  - **Outcome**: Proposal marked approved, changelog updated under v0.9.0
+
+#### :sparkles: What went well
+  - The proposal already contained most of the code snippets so updates were minimal
+  - Automated build and test scripts confirmed no regressions after documentation changes
+
+#### :warning: Pain points
+  - Removing the v0.10.0 section required careful sed ranges to avoid deleting the wrong lines
+
+#### :bulb: Proposed Improvement
+  - Provide a helper script to update version sections in the changelog safely
+
+#### :mortar_board: Learning & Insights
+  - Running the formatter and linter even for doc changes avoids CI surprises
+  - Example build artifacts must be cleaned before committing
+
+#### :link: References
+  - docs/design/proposals/0002-chat-file-message.md
+  - CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.9.0] - 2025-06-22
+## [v0.9.0] - 2025-06-28
 ### Added
 - Added `OpenAIAdminClient` with comprehensive administration modules (projects, API keys, invites, users, service accounts, rate limits, certificates, audit logs, usage).
 - Introduced `Responses` and `Images` API implementations.
@@ -10,11 +10,13 @@
 - Added `validate` method and environment-based creation in `OpenAIClientConfig`.
 - Numerous example programs demonstrating new features.
 - Integrated Codecov and improved CI caching of Dub packages.
+- Added `ChatUserMessageFileContent` type and `userChatMessageWithFile` helper for attaching files in chat messages.
 
 ### Changed
 - Switched optional fields to `mir.algebraic.Nullable`.
 - Standardized request and response structure names.
 - Refactored URL helpers and removed redundant client functions.
+- `ChatUserMessageContentItem` now includes `ChatUserMessageFileContent`. Code that pattern-matches on this alias must handle the new variant; exhaustive `match` expressions may fail to compile with older assumptions.
 
 ### Fixed
 - Corrected numeric literal style and CI paths.

--- a/docs/design/proposals/0002-chat-file-message.md
+++ b/docs/design/proposals/0002-chat-file-message.md
@@ -1,0 +1,91 @@
+---
+title: Chat File Message Support
+date: 2025-06-28
+status: Approved
+---
+
+# Proposal: Chat File Message Support
+
+## Motivation
+OpenAI recently introduced support for providing files directly within chat messages. Users can upload PDFs or text documents via the Files API and reference them in a conversation so the model can answer questions about the content. The current library only supports text and image message types, which prevents building assistants that reason over user documents.
+
+## Goals
+- Represent file attachments in `ChatMessage` so uploaded documents can be used during chat.
+- Mirror the Python API that accepts a `{"type":"file","file":{"file_id":"..."}}` message item.
+- Enable a D example that uploads a file and asks a question about it with `chatCompletion`.
+
+## Non-Goals
+- Full retrieval or search API integration.
+- Client‑side validation of PDF content.
+
+## Solution Sketch
+Introduce a new struct similar to `ChatUserMessageTextContent` and `ChatUserMessageImageContent`:
+
+```d
+@serdeIgnoreUnexpectedKeys
+struct ChatUserMessageFile
+{
+    @serdeKeys("file_id")
+    string fileId;
+}
+
+@serdeIgnoreUnexpectedKeys
+@serdeDiscriminatedField("type", "file")
+struct ChatUserMessageFileContent
+{
+    @serdeKeys("file")
+    ChatUserMessageFile file;
+}
+```
+
+Extend `ChatUserMessageContentItem` to include this type:
+
+```d
+alias ChatUserMessageContentItem = Algebraic!(
+    ChatUserMessageTextContent,
+    ChatUserMessageImageContent,
+    ChatUserMessageFileContent);
+```
+
+Add a helper for constructing a user message with file and text parts:
+
+```d
+ChatMessage userChatMessageWithFile(string text, string fileId, string name = null)
+{
+    ChatUserMessageContentItem[] items;
+
+    ChatUserMessageFileContent fileContent;
+    fileContent.file.fileId = fileId;
+    items ~= ChatUserMessageContentItem(fileContent);
+
+    ChatUserMessageTextContent textContent;
+    textContent.text = text;
+    items ~= ChatUserMessageContentItem(textContent);
+
+    return ChatMessage("user", ChatMessageContent(items), name);
+}
+```
+
+Example usage after uploading a PDF:
+
+```d
+auto uploaded = client.uploadFile(
+    uploadFileRequest("draconomicon.pdf", FilePurpose.UserData));
+auto request = chatCompletionRequest(
+    openai.GPT4OMini, [
+        userChatMessageWithFile("What is the first dragon in the book?", uploaded.id)
+    ],
+    16, 0);
+auto response = client.chatCompletion(request);
+```
+
+## Alternatives
+- Encode file references as plain text and parse them manually on the server.
+- Implement a higher level assistant workflow instead of direct file messages.
+
+## Impact & Risks
+- Adds a new variant to `ChatUserMessageContentItem`; serialization must remain backward compatible.
+- Requires tests covering deserializing/serializing chat messages with the new file type.
+
+## Next Steps
+- None. This proposal was implemented in version 0.9.0.

--- a/docs/design/proposals/INDEX.md
+++ b/docs/design/proposals/INDEX.md
@@ -3,3 +3,4 @@
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | [0001](0001-chat-streaming-design.md) | Chat Streaming Design | Draft | 2025-06-27 |
+| [0002](0002-chat-file-message.md) | Chat File Message Support | Approved | 2025-06-28 |

--- a/examples/chat_files/dub.sdl
+++ b/examples/chat_files/dub.sdl
@@ -1,0 +1,6 @@
+name "chat_files"
+description "Upload a file and ask questions about it using chat completions."
+authors "lempiji"
+license "MIT"
+
+dependency "openai-d" path="../.."

--- a/examples/chat_files/dub.selections.json
+++ b/examples/chat_files/dub.selections.json
@@ -1,0 +1,11 @@
+{
+        "fileVersion": 1,
+        "versions": {
+                "mir-algorithm": "3.22.4",
+                "mir-core": "1.7.3",
+                "mir-cpuid": "1.2.11",
+                "mir-ion": "2.3.4",
+                "openai-d": {"path":"../.."},
+                "silly": "1.1.1"
+        }
+}

--- a/examples/chat_files/source/app.d
+++ b/examples/chat_files/source/app.d
@@ -1,0 +1,18 @@
+import std.stdio;
+import openai;
+
+void main()
+{
+    auto client = new OpenAIClient();
+
+    auto uploaded = client.uploadFile(uploadFileRequest("draconomicon.pdf", FilePurpose.UserData));
+
+    auto request = chatCompletionRequest(
+        openai.GPT4OMini, [
+        userChatMessageWithFile("What is the first dragon in the book?", uploaded.id)
+    ],
+        128, 0);
+
+    auto response = client.chatCompletion(request);
+    writeln(response.choices[0].message.content);
+}


### PR DESCRIPTION
## Summary
- support file attachments in chat messages
- add example program using the new helper
- document compatibility impact in CHANGELOG
- record reflection on implementing file messages
- finalize the proposal with approved status

## Testing
- `dub run dfmt -- source examples`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d all chat_files`


------
https://chatgpt.com/codex/tasks/task_e_685f4e52494c832c99d8425ff7d9f078