### PR TITLE
Add multi-file chat example

### DIFF
--- a/.codex/reflections/2025-06-28-0346-analyze-multiple-chat-files.md
+++ b/.codex/reflections/2025-06-28-0346-analyze-multiple-chat-files.md
@@ -1,0 +1,20 @@
+### :book: Reflection for [2025-06-28 03:46]
+  - **Task**: Add example uploading multiple files
+  - **Objective**: Demonstrate how to attach several files in a chat message and guide the model to analyze them.
+  - **Outcome**: Updated the chat_files example to upload two text files and send them with a question. Documented the change and ensured style and tests pass.
+
+#### :sparkles: What went well
+  - dfmt and dscanner ran without issues.
+  - Example built successfully with the helper script.
+
+#### :warning: Pain points
+  - build_examples script ignored the chat_files group when using the `core` mode which the instructions initially suggested.
+
+#### :bulb: Proposed Improvement
+  - Document in AGENTS.md that groups with underscores require the `all` mode when building examples.
+
+#### :mortar_board: Learning & Insights
+  - Verified how to manually construct `ChatMessage` with multiple `ChatUserMessageFileContent` entries.
+
+#### :link: References
+  - `scripts/build_examples.d` logic for group selection

--- a/.codex/reflections/2025-06-28-0415-update-chat-files-cleanup.md
+++ b/.codex/reflections/2025-06-28-0415-update-chat-files-cleanup.md
@@ -1,0 +1,20 @@
+### :book: Reflection for [2025-06-28 04:15]
+  - **Task**: Improve multi-file chat example
+  - **Objective**: Address reviewer feedback on sample text, cleanup, and changelog
+  - **Outcome**: Enhanced sample data, automatic file cleanup, and updated changelog. Formatting, linting, tests, coverage, and example build all succeeded.
+
+#### :sparkles: What went well
+  - Using `scope(exit)` provided a clean way to remove uploaded files.
+  - All project checks and builds passed without issues.
+
+#### :warning: Pain points
+  - Waiting for dfmt and dscanner dependencies was slow because they were re-fetched each run.
+
+#### :bulb: Proposed Improvement
+  - Cache dfmt and dscanner binaries locally to speed up formatting and linting steps.
+
+#### :mortar_board: Learning & Insights
+  - Merging changelog sections requires careful editing to preserve bullet order.
+
+#### :link: References
+  - `scope(exit)` cleanup pattern in D documentation

--- a/.codex/reflections/2025-06-28-0429-update-chat-files-helper.md
+++ b/.codex/reflections/2025-06-28-0429-update-chat-files-helper.md
@@ -1,0 +1,21 @@
+### :book: Reflection for [2025-06-28 04:29]
+  - **Task**: Improve chat_files example and library helper
+  - **Objective**: Address reviewer comments to clean up uploads and add a helper for multi-file messages
+  - **Outcome**: Added userChatMessageWithFiles helper, updated example cleanup, merged changelog entry, and ensured all project checks pass
+
+#### :sparkles: What went well
+  - Running dfmt and dscanner produced no style issues
+  - The new helper made the example code much shorter
+
+#### :warning: Pain points
+  - Manually inspecting coverage outputs is tedious
+
+#### :bulb: Proposed Improvement
+  - Provide a script to summarize coverage percentages automatically
+
+#### :mortar_board: Learning & Insights
+  - scope(exit) near each upload ensures failed uploads are handled correctly
+  - Writing helpers keeps example code readable
+
+#### :link: References
+  - openai/chat.d helper functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
-
-## [v0.9.0] - 2025-06-28
+## [v0.9.0] - Unreleased
 ### Added
 - Added `OpenAIAdminClient` with comprehensive administration modules (projects, API keys, invites, users, service accounts, rate limits, certificates, audit logs, usage).
 - Introduced `Responses` and `Images` API implementations.
@@ -11,6 +10,8 @@
 - Numerous example programs demonstrating new features.
 - Integrated Codecov and improved CI caching of Dub packages.
 - Added `ChatUserMessageFileContent` type and `userChatMessageWithFile` helper for attaching files in chat messages.
+- Added `userChatMessageWithFiles` helper for attaching multiple files in one chat message.
+- chat_files example now uploads multiple files and asks the model to analyze both.
 
 ### Changed
 - Switched optional fields to `mir.algebraic.Nullable`.

--- a/examples/chat_files/data/file1.txt
+++ b/examples/chat_files/data/file1.txt
@@ -1,0 +1,3 @@
+This is the first sample text file used in the chat_files example.
+It contains a short story about a quick brown fox jumping over a lazy dog.
+The purpose is to give the model a bit of context to summarize.

--- a/examples/chat_files/data/file2.txt
+++ b/examples/chat_files/data/file2.txt
@@ -1,0 +1,3 @@
+This is the second sample text file.
+It describes how diligent cats observe their surroundings and often ignore the antics of nearby dogs.
+This file provides additional material for the model to analyze.

--- a/examples/chat_files/source/app.d
+++ b/examples/chat_files/source/app.d
@@ -5,13 +5,23 @@ void main()
 {
     auto client = new OpenAIClient();
 
-    auto uploaded = client.uploadFile(uploadFileRequest("draconomicon.pdf", FilePurpose.UserData));
+    auto upload1 = client.uploadFile(uploadFileRequest("data/file1.txt", FilePurpose.UserData));
+    scope (exit)
+        client.deleteFile(upload1.id);
+
+    auto upload2 = client.uploadFile(uploadFileRequest("data/file2.txt", FilePurpose.UserData));
+    scope (exit)
+        client.deleteFile(upload2.id);
 
     auto request = chatCompletionRequest(
-        openai.GPT4OMini, [
-        userChatMessageWithFile("What is the first dragon in the book?", uploaded.id)
+        openai.GPT4OMini,
+        [
+        userChatMessageWithFiles(
+            "Summarize the contents of both files.",
+            [upload1.id, upload2.id])
     ],
-        128, 0);
+        128,
+        0);
 
     auto response = client.chatCompletion(request);
     writeln(response.choices[0].message.content);


### PR DESCRIPTION
## Summary
- add `userChatMessageWithFiles` helper with tests
- use helper in `chat_files` example and clean up files individually
- document the new helper in the changelog
- record a reflection about the improvements

## Testing
- `dub run dfmt -- source`
- `dub run dfmt -- examples/chat_files`
- `dub lint --dscanner-config dscanner.ini`
- `dub test`
- `dub test --coverage --coverage-ctfe`
- `rdmd scripts/build_examples.d all chat_files`


------
https://chatgpt.com/codex/tasks/task_e_685f6447a6e0832c83a8459fa1094cfb